### PR TITLE
[Chore] 운영 환경을 위한 `application-prod.yml` 파일 작성(#14)

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,28 @@
+spring:
+  application:
+    name: wagle-server
+  datasource:
+    # 1. DB 주소: 프라이빗 서버의 비공개 IP를 도커가 주입해줄 수 있도록 설정
+    url: jdbc:mysql://${DB_URL}:3306/waglewagle?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update # 초기 운영 환경이므로 update로 설정
+    properties:
+      hibernate:
+        format_sql: false # 운영 환경에서 로그 부하를 줄이기 위해 false로 설정
+  data:
+    redis:
+      # 2. Redis 주소
+      host: ${REDIS_HOST}
+      port: 6379
+      password: ${REDIS_PASSWORD}
+
+jwt:
+  token:
+    # 3. 시크릿 키는 환경 변수로 분리
+    secret-key: ${JWT_SECRET_KEY}
+    expiration:
+      access: 604800000 # 일주일 (기존 유지)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: local # 기본값을 local로 설정
   application:
     name: wagle-server
   datasource:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #14

## #️⃣ 작업 내용

* **운영 환경 프로필 추가**: 배포 서버 전용 설정 파일인 `application-prod.yml`을 생성했습니다.
* **환경 변수화(`${}`)**: DB 주소, 비밀번호, JWT 시크릿 키 등 민감 정보를 코드에서 분리하여 런타임에 주입받을 수 있도록 구성했습니다.
* **기본 프로필 설정**: 로컬 실행 시 혼선이 없도록 `application.yml`의 기본 프로필을 `local`로 명시했습니다.
* **보안 및 협업 가이드 추가**:
  * `.gitignore`에 `.env` 파일을 추가하여 민감 정보 유출을 방지했습니다.
  * 팀원들이 배포 환경 세팅 시 참고할 수 있도록 변수 목록이 담긴 파일을 추후 프로젝트 디코 등에 남길 예정입니다.



## #️⃣ 테스트 결과

* **로컬 빌드 테스트**: `./gradlew build` 시 정상적으로 빌드 완료됨을 확인했습니다.

## #️⃣ 셀프 체크리스트

* [x] (Server) 로컬 환경에서 정상적으로 빌드되나요?
* [x] (Server) 예시 데이터를 통해 테스트를 마쳤나요?
* [ ] (Client) 화면이 깨지지 않고 렌더링되나요?
* [ ] Swagger 문서가 최신화되었나요? (API 변경 시)
* [x] 코드 컨벤션을 준수했나요?

## #️⃣ 리뷰 요구사항

* `application-prod.yml`에 빠진 환경 변수가 없는지, 변수 명명 규칙(`DB_URL`, `JWT_SECRET_KEY` 등)이 적절한지 리뷰 부탁드립니다.
