### PR TITLE
[Fix] 배포 환경에서 스프링 시큐리티 스웨거 접근 오류 해결 (#18)

### DIFF
--- a/src/main/java/com/waglewagle/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/waglewagle/server/global/security/config/SecurityConfig.java
@@ -40,6 +40,9 @@ public class SecurityConfig {
 
                 // 2. 경로별 권한 설정
                 .authorizeHttpRequests(authorize -> authorize
+                        // 에러 페이지로 포워딩되는 요청은 무조건 허가
+                        .dispatcherTypeMatchers(jakarta.servlet.DispatcherType.ERROR).permitAll()
+
                         // 스웨거 및 health의 경우 인증 불필요
                         .requestMatchers("/swagger-ui/**",
                                 "/swagger-ui.html",
@@ -47,8 +50,7 @@ public class SecurityConfig {
                                 "/v3/api-docs",
                                 "/swagger-resources/**",
                                 "/webjars/**",
-                                "/health",
-                                "/error").permitAll()
+                                "/health").permitAll()
 
                         // 나머지는 다 인증 필요
                         .anyRequest().authenticated()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #18

## #️⃣ 작업 내용

배포 환경(NCP)에서 Swagger 접속 시 발생하던 `AUTH4000`(인증 오류) 및 404 Not Found 문제를 해결했습니다.

* **Spring Security 설정 수정**
  * 발생 원인: 존재하지 않는 경로 요청(404) 발생 시, 스프링 내부적으로 `/error`로 포워딩되는 과정에서 인증 필터에 막혀 `AUTH4000` 에러로 덮어씌워지는 현상 확인.
  * 해결: `SecurityConfig`에 `dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()`을 추가하여, 진짜 에러의 원인을 파악하고 잘못된 인증 에러 반환을 방지함.
  * Swagger 관련 리소스 경로들에 대한 접근 권한(`permitAll`) 재확인 및 정비.


* **Nginx 라우팅 설정 수정**
  * 발생 원인: `default.conf`에서 `/swagger-ui/` 경로를 억지로 `/v3/api-docs`로 매핑해두어, Swagger HTML 화면이 내부 JSON 명세서 데이터를 불러오지 못하고 경로가 꼬이는(404 발생) 문제 확인.
  * 해결: 잘못된 Swagger 전용 `location` 블록을 제거하고, 모든 요청(`/`)이 정상적으로 Spring Boot 컨테이너(`wagle-api:8080`)로 전달되도록 프록시 설정 원복.

## #️⃣ 테스트 결과

* NCP 배포 서버에서 Swagger 주소 접속 시, 인증 에러 없이 정상적으로 API 명세서 UI가 렌더링되고 내부 JSON 데이터를 성공적으로 불러오는 것을 확인했습니다.

<img width="1280" height="762" alt="화면 캡처 2026-03-04 144640" src="https://github.com/user-attachments/assets/1c2c84d2-8ba8-4ae4-b5ce-843ff756ce1f" />

## #️⃣ 셀프 체크리스트

* [x] (Server) 로컬 환경에서 정상적으로 빌드되나요?
* [x] (Server) 예시 데이터를 통해 테스트를 마쳤나요?
* [ ] (Client) 화면이 깨지지 않고 렌더링되나요?
* [x] Swagger 문서가 최신화되었나요? (API 변경 시)
* [x] 코드 컨벤션을 준수했나요?

## #️⃣ 리뷰 요구사항

Nginx 프록시 설정과 Spring Security 필터가 겹치면서 디버깅이 꽤 까다로웠던 이슈였습니다. 배포 환경 설정이 변경되었으니 팀원분들은 배포된 스웨거 주소로 잘 접속되는지 한 번씩 확인 부탁드립니다!

스웨거 접근 주소 : http://wagle-wagle.my-project.cloud/swagger-ui.html

💡 **주의사항 (중요)**
기존에 접속하셨던 브라우저에 404 에러나 잘못된 리다이렉트 캐시가 강하게 남아있어 접속이 안 될 수 있습니다. **안 들어가진다면 반드시 브라우저 '시크릿 창(Incognito)'으로 접속해 보시거나 인터넷 기록 삭제를 진행해 주세요!**
