### PR TITLE
[Infra] CI/CD 파이프라인 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,57 @@
+name: CD
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: staging
+    concurrency:
+      group: deploy-develop
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/wagle-server:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Copy docker-compose.yml to NCP
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ vars.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME || 'root' }}
+          key: ${{ secrets.NCP_SSH_KEY }}
+          source: "docker-compose.yml"
+          target: "~/deploy"
+
+      - name: Deploy to NCP via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ vars.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME || 'root' }}
+          key: ${{ secrets.NCP_SSH_KEY }}
+          script: |
+            cd ~/deploy
+            export DOCKERHUB_USERNAME=${{ vars.DOCKERHUB_USERNAME }}
+            export DB_HOST=${{ vars.DB_HOST }}
+            export DB_USERNAME=${{ vars.DB_USERNAME }}
+            export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
+            docker pull ${{ vars.DOCKERHUB_USERNAME }}/wagle-server:latest
+            docker-compose up -d wagle-app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: wagle
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+      redis:
+        image: redis:alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build and Test with Gradle
+        run: ./gradlew build --no-daemon

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,61 @@
+name: Deploy to NCP
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build and Test with Gradle
+        run: ./gradlew build --no-daemon
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/wagle-server:latest
+
+      - name: Copy docker-compose.yml to NCP
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME }}
+          key: ${{ secrets.NCP_SSH_KEY }}
+          source: "docker-compose.yml"
+          target: "~/deploy"
+
+      - name: Deploy to NCP via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME }}
+          key: ${{ secrets.NCP_SSH_KEY }}
+          script: |
+            cd ~/deploy
+            export DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+            export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/wagle-server:latest
+            docker-compose up -d wagle-app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,46 +1,53 @@
-services:
-  # 1. Redis: 퍼블릭 서버 내부에 띄울 레디스
-  wagle-redis:
-    image: redis:latest
-    container_name: wagle-redis
-    restart: always
-    command: redis-server --requirepass ${REDIS_PASSWORD}
-    ports:
-      - "6379:6379"
-    networks:
-      - wagle-network
+version: '3.8'
 
-  # 2. Spring Boot: 레포 내부 Dockerfile을 사용하여 빌드
-  wagle-api:
-    build: .
-    container_name: wagle-api
+services:
+  # 1. App (Spring Boot)
+  wagle-app:
+    image: ${DOCKERHUB_USERNAME}/wagle-server:latest
+    container_name: wagle-app
     restart: always
+    ports:
+      - "8080:8080"
     environment:
-      - SPRING_PROFILES_ACTIVE=prod
-      - DB_URL=${DB_URL}
+      - DB_HOST=${DB_HOST}
       - DB_USERNAME=${DB_USERNAME}
       - DB_PASSWORD=${DB_PASSWORD}
       - REDIS_HOST=wagle-redis
-      - REDIS_PASSWORD=${REDIS_PASSWORD}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
     depends_on:
       - wagle-redis
     networks:
       - wagle-network
 
-  # 3. Nginx: 외부 요청을 받아 스프링으로 전달 (리버스 프록시)
-  wagle-nginx:
-    image: nginx:latest
-    container_name: wagle-nginx
+  # 2. MySQL (데이터베이스)
+  wagle-db:
+    image: mysql:8.0
+    container_name: wagle-mysql
     restart: always
     ports:
-      - "80:80"
-      - "443:443"
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-root}
+      MYSQL_DATABASE: wagle
+      TZ: Asia/Seoul
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
     volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
-      - /etc/letsencrypt:/etc/letsencrypt:ro
-    depends_on:
-      - wagle-api
+      - ./db/mysql_data:/var/lib/mysql
+    networks:
+      - wagle-network
+
+  # 3. Redis (캐시 & 위치 저장)
+  wagle-redis:
+    image: redis:alpine
+    container_name: wagle-redis
+    restart: always
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes
+    volumes:
+      - ./db/redis_data:/data
     networks:
       - wagle-network
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,7 +3,7 @@ spring:
     name: wagle-server
   datasource:
     # 1. DB 주소: 프라이빗 서버의 비공개 IP를 도커가 주입해줄 수 있도록 설정
-    url: jdbc:mysql://${DB_URL}:3306/waglewagle?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_HOST}:3306/waglewagle?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -18,7 +18,6 @@ spring:
       # 2. Redis 주소
       host: ${REDIS_HOST}
       port: 6379
-      password: ${REDIS_PASSWORD}
 
 jwt:
   token:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,10 @@
 spring:
-  profiles:
-    active: local # 기본값을 local로 설정
   application:
     name: wagle-server
   datasource:
-    url: jdbc:mysql://localhost:3306/wagle?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_HOST:localhost}:3306/wagle?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
     username: root
-    password: root  # 도커 비밀번호 (root로 설정했음)
+    password: ${DB_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
@@ -16,11 +14,11 @@ spring:
         format_sql: true
   data:
     redis:
-      host: localhost
+      host: ${REDIS_HOST:localhost}
       port: 6379
 
 jwt:
   token:
-    secret-key: "waglewagle-secret-key-must-be-very-long-and-secure-enough" # 로컬 실행용 시크릿 키
+    secret-key: ${JWT_SECRET_KEY:waglewagle-secret-key-must-be-very-long-and-secure-enough}
     expiration:
-      access: 604800000 # 일주일
+      access: 604800000


### PR DESCRIPTION
## 관련 이슈
closes #24

## 작업 내용

### CI (`ci.yml`)
- `develop` 브랜치 PR 생성 시 트리거
- MySQL 8.0 / Redis 서비스 컨테이너로 실제 DB 연결 테스트
- `setup-java` 내장 Gradle 캐시 적용

### CD (`cd.yml`)
- `develop` 브랜치 머지(push) 시 트리거
- Docker 이미지 빌드 → DockerHub push → NCP 서버 SSH 배포
- GHA Docker 레이어 캐시 적용으로 빌드 속도 최적화
- `concurrency` 설정으로 동시 배포 방지
- GitHub Environment(`staging`) 기반 secrets/variables 분리 관리

### 환경변수 정비
- `docker-compose.yml`: prod 기준 환경변수 정비 (`DB_HOST`, `DB_USERNAME`, `JWT_SECRET_KEY` 등 추가)
- `application.yml`: `JWT_SECRET_KEY` 기본값 추가
- `application-prod.yml`: `DB_URL` → `DB_HOST` 통일, Redis 비밀번호 제거

## 등록 필요한 GitHub Secrets/Variables

| 종류 | 이름 | 위치 |
|---|---|---|
| Variable | `DOCKERHUB_USERNAME` | repository |
| Variable | `NCP_HOST` | staging environment |
| Variable | `DB_HOST` | staging environment |
| Variable | `DB_USERNAME` | staging environment |
| Secret | `DOCKERHUB_TOKEN` | repository |
| Secret | `NCP_SSH_KEY` | staging environment |
| Secret | `DB_PASSWORD` | staging environment |
| Secret | `JWT_SECRET_KEY` | staging environment |

## 테스트 계획
- [x] Secrets/Variables 등록
- [ ] `develop` PR 생성 → CI 정상 동작 확인
- [ ] `develop` 머지 → CD 정상 동작 확인 (DockerHub push, NCP 배포)
- [ ] GitHub Rulesets check status 적용