### PR TITLE
[Fix] SecurityConfig 설정 오류로 인해 @PreAuthorize 어노테이션이 제대로 작동하지 않는 문제 해결 (#22)

### DIFF
--- a/src/main/java/com/waglewagle/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/waglewagle/server/global/security/config/SecurityConfig.java
@@ -52,8 +52,9 @@ public class SecurityConfig {
                                 "/webjars/**",
                                 "/health").permitAll()
 
-                        // 나머지는 다 인증 필요
-                        .anyRequest().authenticated()
+                        // 나머지는 다 인증 불필요
+                        // 인증이 필요한 메소드 위 @PreAuthorize을 붙일 것
+                        .anyRequest().permitAll()
                 )
 
                 // 3. JwtFilter를 시큐리티 필터 체인에 끼워 넣기


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #22

## #️⃣ 작업 내용

* `SecurityConfig`의 `filterChain` 내 인가 설정 변경 (`.anyRequest().authenticated()` -> `.anyRequest().permitAll()`)
* 모든 API 요청에 대해 강제로 인증을 요구하던 문제를 해결하여, 공개 API(예: 단순 조회 API)가 토큰 없이도 정상 호출되도록 수정했습니다.
* 이제 API 엔드포인트의 인증/인가 여부는 컨트롤러의 `@PreAuthorize` 어노테이션 유무에 따라 개별적으로 동작합니다.

## #️⃣ 테스트 결과

* **공개 API ( `@PreAuthorize` 없음 )**: Authorization 헤더 없이 요청 시 `200 OK` 및 정상 데이터 반환 확인
* **보호된 API ( `@PreAuthorize("isAuthenticated()")` 등 적용 )**:
  * 토큰 없이 요청 시 `401 Unauthorized` 에러 반환 확인
  * 유효한 JWT 토큰 포함하여 요청 시 `200 OK` 정상 동작 확인

## #️⃣ 셀프 체크리스트

* [x] (Server) 로컬 환경에서 정상적으로 빌드되나요?
* [x] (Server) 예시 데이터를 통해 테스트를 마쳤나요?
* [ ] (Client) 화면이 깨지지 않고 렌더링되나요?
* [ ] Swagger 문서가 최신화되었나요? (API 변경 시) (해당 없음)
* [x] 코드 컨벤션을 준수했나요?

## #️⃣ 리뷰 요구사항

전역 설정이 `permitAll()`로 변경되었기 때문에, **앞으로 인증이 필요한 모든 API 엔드포인트에는 반드시 `@PreAuthorize` 어노테이션을 꼼꼼하게 붙여주셔야 합니다.** 혹시 기존 API 중에서 인증이 필요한데 어노테이션이 누락된 곳이 있는지 리뷰 과정에서 한 번씩 확인 부탁드립니다!

## 📎 참고 자료 (Optional)

* 변경된 파일: `SecurityConfig.java`
