### PR TITLE
[Fix] trigger-ai-fix.sh Antigravity 절대경로 적용

### DIFF
--- a/trigger-ai-fix.sh
+++ b/trigger-ai-fix.sh
@@ -17,7 +17,7 @@ cd "$PROJECT_DIR" || exit 1
 
 # 노드 및 모델 티어별 명령어 설정
 # 사용자 요청 방식에 맞춘 Antigravity 전용 백그라운드 명령어
-AI_CLI_COMMAND="antigravity chat"
+AI_CLI_COMMAND="/Users/seoyeon/.antigravity/antigravity/bin/antigravity chat"
 
 # 15회 이상 실패 시 안전장치 (휴먼 개입) - n8n에서 사전에 걸러지지만 이중 방어
 if [ "$FAIL_COUNT" -ge 15 ]; then


### PR DESCRIPTION
## #️⃣ 연관된 이슈

N/A

## #️⃣ 작업 내용

- `trigger-ai-fix.sh`의 `AI_CLI_COMMAND`를 `antigravity chat` → 절대경로로 변경
  - n8n에서 스크립트를 백그라운드 실행할 때 PATH가 설정되지 않아 `antigravity` 명령어를 찾지 못하는 문제 수정

```sh
# Before
AI_CLI_COMMAND="antigravity chat"

# After
AI_CLI_COMMAND="/Users/seoyeon/.antigravity/antigravity/bin/antigravity chat"
```

## #️⃣ 셀프 체크리스트

- [x] 코드 컨벤션을 준수했나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)