### PR TITLE
fix(ci): 디스크 풀로 인한 SCP 실패 수정 - 배포 전 Docker 이미지 정리

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -73,5 +73,6 @@ jobs:
             export DB_USERNAME=${{ vars.DB_USERNAME }}
             export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
             export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
+            docker image prune -af
             docker pull ${{ vars.DOCKERHUB_USERNAME }}/wagle-server:latest
             docker compose up -d --no-deps --force-recreate wagle-app


### PR DESCRIPTION
## Summary

서버 디스크가 100% 가득 차서 SCP 파일 전송이 0byte 파일로 실패하던 문제를 수정합니다.

**근본 원인**: `/dev/vda2` 9.8G 디스크 100% 사용으로 SFTP 쓰기 실패 → tar.gz가 0byte로 생성 → `gzip: unexpected end of file` 압축 해제 실패 → `Process exited with status 1`

**해결**: `docker pull` 전에 `docker image prune -af`로 미사용 이미지 정리하여 디스크 공간 확보 (실측 약 2GB 확보)

## 변경 파일

- `.github/workflows/_deploy.yml`: `docker image prune -af` 추가

## Test Plan

- [ ] CD 워크플로우 실행 시 SCP 단계 정상 통과 확인
- [ ] 서버 디스크 사용량 배포 후 70~80% 수준 유지 확인