### PR TITLE
[Fix] 로컬 환경 Docker Compose 포트 충돌 문제 해결 (#54)

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -7,7 +7,7 @@ services:
     container_name: wagle-mysql
     restart: always
     ports:
-      - "3306:3306"
+      - "13306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: root  # application.yml 비밀번호랑 맞춰주세요!
       MYSQL_DATABASE: wagle      # 자동으로 생성될 DB 이름
@@ -24,7 +24,7 @@ services:
     container_name: wagle-redis
     restart: always
     ports:
-      - "6379:6379"
+      - "16379:6379"
     command: redis-server --appendonly yes # 데이터 영구 저장 옵션
     volumes:
       - ./db/redis_data:/data

--- a/src/main/java/com/waglewagle/server/domain/health/controller/HealthController.java
+++ b/src/main/java/com/waglewagle/server/domain/health/controller/HealthController.java
@@ -9,6 +9,6 @@ public class HealthController implements HealthControllerDocs {
     @GetMapping("/health")
     @Override
     public String healthCheck() {
-        return "I'm alive!!!";
+        return "I'm alive now!";
     }
 }

--- a/src/main/java/com/waglewagle/server/domain/health/controller/HealthController.java
+++ b/src/main/java/com/waglewagle/server/domain/health/controller/HealthController.java
@@ -9,6 +9,6 @@ public class HealthController implements HealthControllerDocs {
     @GetMapping("/health")
     @Override
     public String healthCheck() {
-        return "I'm alive now!!";
+        return "I'm alive now!";
     }
 }

--- a/src/main/java/com/waglewagle/server/domain/health/controller/HealthController.java
+++ b/src/main/java/com/waglewagle/server/domain/health/controller/HealthController.java
@@ -9,6 +9,6 @@ public class HealthController implements HealthControllerDocs {
     @GetMapping("/health")
     @Override
     public String healthCheck() {
-        return "I'm alive now!";
+        return "I'm alive now!!";
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: wagle-server
   datasource:
-    url: jdbc:mysql://${DB_HOST:localhost}:3306/wagle?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_HOST:localhost}:13306/wagle?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
     username: root
     password: ${DB_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -15,7 +15,7 @@ spring:
   data:
     redis:
       host: ${REDIS_HOST:localhost}
-      port: 6379
+      port: 16379
 
 jwt:
   token:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #54

## #️⃣ 작업 내용

Windows 로컬 환경에서 `docker-compose` 실행 시 발생하는 포트 바인딩 권한 거부(winnat 자동 포트 예약 버그) 및 로컬 프로세스 충돌 문제를 해결했습니다.
매번 시스템 포트를 수동으로 초기화(`net stop winnat`)하는 번거로움을 없애고 개발 생산성을 높이기 위해, 충돌 가능성이 적은 안전한 포트로 우회하도록 설정을 변경했습니다.

* `docker-compose-local.yml` 내 호스트 포트 변경
  * MySQL: `3306` -> `13306`
  * Redis: `6379` -> `16379`
* `application.yml`의 DB 및 Redis 접속 포트 정보를 위 변경 사항에 맞춰 동일하게 업데이트

## #️⃣ 테스트 결과

- `docker compose -f docker-compose-local.yml up -d` 명령어 실행 시 포트 충돌 에러 없이 `wagle-mysql` 및 `wagle-redis` 컨테이너가 정상적으로 `Up` 상태가 되는 것을 확인했습니다.
- 애플리케이션 실행 시 변경된 포트(13306, 16379)를 통해 DB와 Redis에 정상적으로 커넥션이 맺어지는 것을 확인했습니다.

## #️⃣ 셀프 체크리스트

- [x] (Server) 로컬 환경에서 정상적으로 빌드되나요?
- [x] (Server) 예시 데이터를 통해 테스트를 마쳤나요?
- [ ] (Client) 화면이 깨지지 않고 렌더링되나요?
- [ ] Swagger 문서가 최신화되었나요? (API 변경 시)
- [x] 코드 컨벤션을 준수했나요?

## #️⃣ 리뷰 요구사항

**Window를 사용하시는 분들**은 이번 PR 반영 후 로컬에서 `docker-compose`를 다시 실행해 보시고 정상적으로 컨테이너가 구동되는지 확인 부탁드립니다. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 로컬 개발 환경의 데이터베이스 및 캐싱 서비스 포트 설정을 업데이트했습니다.
  * 헬스 체크 엔드포인트 메시지를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->