### PR TITLE
[Feat] 실시간 위치 전송 및 혼잡도 조회 API 구현 (Redis + H3)

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -15,8 +15,6 @@ services:
     command: # 한글 깨짐 방지 설정
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
-    volumes:
-      - ./db/mysql_data:/var/lib/mysql # 데이터가 날아가지 않게 로컬에 저장
 
   # 2. Redis (캐시 & 위치 저장)
   wagle-redis:
@@ -25,6 +23,3 @@ services:
     restart: always
     ports:
       - "16379:6379"
-    command: redis-server --appendonly yes # 데이터 영구 저장 옵션
-    volumes:
-      - ./db/redis_data:/data

--- a/src/main/java/com/waglewagle/server/domain/festivalMap/controller/FestivalMapController.java
+++ b/src/main/java/com/waglewagle/server/domain/festivalMap/controller/FestivalMapController.java
@@ -2,6 +2,7 @@ package com.waglewagle.server.domain.festivalMap.controller;
 
 import com.waglewagle.server.domain.festivalMap.dto.FestivalMapDTO;
 import com.waglewagle.server.domain.festivalMap.dto.CongestionDTO;
+import com.waglewagle.server.domain.festivalMap.service.CongestionService;
 import com.waglewagle.server.global.apiPayload.ApiResponse;
 import com.waglewagle.server.global.apiPayload.code.GeneralSuccessCode;
 import com.waglewagle.server.global.apiPayload.dto.ListResponseDTO;
@@ -18,6 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
 public class FestivalMapController implements FestivalMapControllerDocs {
+    final CongestionService congestionService;
+
     @GetMapping("/festivals/{festivalId}/maps")
     @PreAuthorize("isAuthenticated()")
     @Override
@@ -33,6 +36,7 @@ public class FestivalMapController implements FestivalMapControllerDocs {
     public ApiResponse<CongestionDTO.CongestionResponse> getCongestion(
             @PathVariable Long mapId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        return ApiResponse.onSuccess(GeneralSuccessCode.OK, null);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK,
+                congestionService.getCongestion(mapId));
     }
 }

--- a/src/main/java/com/waglewagle/server/domain/festivalMap/repository/FestivalMapRepository.java
+++ b/src/main/java/com/waglewagle/server/domain/festivalMap/repository/FestivalMapRepository.java
@@ -3,5 +3,8 @@ package com.waglewagle.server.domain.festivalMap.repository;
 import com.waglewagle.server.domain.festivalMap.entity.FestivalMap;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FestivalMapRepository extends JpaRepository<FestivalMap, Long> {
+    List<FestivalMap> findByFestivalId(Long festivalId);
 }

--- a/src/main/java/com/waglewagle/server/domain/festivalMap/service/CongestionService.java
+++ b/src/main/java/com/waglewagle/server/domain/festivalMap/service/CongestionService.java
@@ -1,0 +1,52 @@
+package com.waglewagle.server.domain.festivalMap.service;
+
+import com.waglewagle.server.domain.festivalMap.dto.CongestionDTO;
+import com.waglewagle.server.domain.festivalMap.repository.FestivalMapRepository;
+import com.waglewagle.server.global.apiPayload.code.GeneralErrorCode;
+import com.waglewagle.server.global.apiPayload.exception.GeneralException;
+import com.waglewagle.server.global.redis.repository.LocationRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CongestionService {
+
+    private final FestivalMapRepository festivalMapRepository;
+    private final LocationRedisRepository locationRedisRepository;
+
+    public CongestionDTO.CongestionResponse getCongestion(Long mapId) {
+        // 맵 존재 여부 확인
+        festivalMapRepository.findById(mapId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.MAP_NOT_FOUND));
+
+        Map<String, Integer> cellCounts = locationRedisRepository.getCellCounts(mapId);
+
+        int totalCount = cellCounts.values().stream().mapToInt(Integer::intValue).sum();
+
+        List<CongestionDTO.ZoneInfo> zones = cellCounts.entrySet().stream()
+                .map(e -> new CongestionDTO.ZoneInfo(
+                        e.getKey(),
+                        e.getValue(),
+                        calculateLevel(e.getValue())
+                ))
+                .toList();
+
+        return new CongestionDTO.CongestionResponse(
+                System.currentTimeMillis(),
+                totalCount,
+                zones
+        );
+    }
+
+    // 혼잡도 4단계 (셀당 절대 인원 기준)
+    private int calculateLevel(int count) {
+        if (count >= 31) return 4;
+        if (count >= 16) return 3;
+        if (count >= 6)  return 2;
+        return 1;
+    }
+}

--- a/src/main/java/com/waglewagle/server/domain/visitor/controller/VisitorController.java
+++ b/src/main/java/com/waglewagle/server/domain/visitor/controller/VisitorController.java
@@ -2,21 +2,15 @@ package com.waglewagle.server.domain.visitor.controller;
 
 import com.waglewagle.server.domain.visitor.dto.VisitorDTO;
 import com.waglewagle.server.domain.visitor.dto.VisitorLocationDTO;
-import com.waglewagle.server.domain.visitor.entity.Visitor;
-import com.waglewagle.server.domain.visitor.repository.VisitorLocationService;
-import com.waglewagle.server.domain.visitor.repository.VisitorRepository;
+import com.waglewagle.server.domain.visitor.service.VisitorLocationService;
 import com.waglewagle.server.domain.visitor.service.VisitorService;
 import com.waglewagle.server.global.apiPayload.ApiResponse;
 import com.waglewagle.server.global.apiPayload.code.GeneralSuccessCode;
-import com.waglewagle.server.global.apiPayload.exception.GeneralException;
 import com.waglewagle.server.global.security.userdetails.CustomUserDetails;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import static com.waglewagle.server.global.apiPayload.code.GeneralErrorCode.LOGIN_REQUIRED;
 
 
 @RestController

--- a/src/main/java/com/waglewagle/server/domain/visitor/controller/VisitorController.java
+++ b/src/main/java/com/waglewagle/server/domain/visitor/controller/VisitorController.java
@@ -3,6 +3,8 @@ package com.waglewagle.server.domain.visitor.controller;
 import com.waglewagle.server.domain.visitor.dto.VisitorDTO;
 import com.waglewagle.server.domain.visitor.dto.VisitorLocationDTO;
 import com.waglewagle.server.domain.visitor.entity.Visitor;
+import com.waglewagle.server.domain.visitor.repository.VisitorLocationService;
+import com.waglewagle.server.domain.visitor.repository.VisitorRepository;
 import com.waglewagle.server.domain.visitor.service.VisitorService;
 import com.waglewagle.server.global.apiPayload.ApiResponse;
 import com.waglewagle.server.global.apiPayload.code.GeneralSuccessCode;
@@ -23,6 +25,7 @@ import static com.waglewagle.server.global.apiPayload.code.GeneralErrorCode.LOGI
 public class VisitorController implements VisitorControllerDocs {
 
     private final VisitorService visitorService;
+    private final VisitorLocationService visitorLocationService;
 
     @PostMapping("/visitors")
     @Override
@@ -47,6 +50,8 @@ public class VisitorController implements VisitorControllerDocs {
             @PathVariable Long festivalId,
             VisitorLocationDTO.LocationUpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        return ApiResponse.onSuccess(GeneralSuccessCode.OK, null);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK,
+                visitorLocationService.updateLocation(
+                        festivalId, userDetails.getUsername(), request));
     }
 }

--- a/src/main/java/com/waglewagle/server/domain/visitor/repository/VisitorLocationService.java
+++ b/src/main/java/com/waglewagle/server/domain/visitor/repository/VisitorLocationService.java
@@ -1,0 +1,77 @@
+package com.waglewagle.server.domain.visitor.repository;
+
+import com.uber.h3core.H3Core;
+import com.waglewagle.server.domain.festivalMap.entity.FestivalMap;
+import com.waglewagle.server.domain.festivalMap.repository.FestivalMapRepository;
+import com.waglewagle.server.domain.visitor.dto.VisitorLocationDTO;
+import com.waglewagle.server.global.redis.repository.LocationRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class VisitorLocationService {
+
+    private final FestivalMapRepository festivalMapRepository;
+    private final LocationRedisRepository locationRedisRepository;
+
+    private static final H3Core h3 = createH3();
+    private static final int H3_RESOLUTION = 14;
+    private static final long LOCATION_UPDATE_INTERVAL = 3000L;
+
+    private static H3Core createH3() {
+        try { return H3Core.newInstance(); }
+        catch (Exception e) { throw new RuntimeException("H3 초기화 실패", e); }
+    }
+
+    public VisitorLocationDTO.LocationUpdateResponse updateLocation(
+            Long festivalId, String uuid,
+            VisitorLocationDTO.LocationUpdateRequest request) {
+
+        double lat = request.lat();
+        double lng = request.lng();
+
+        // 1. 축제에 속한 맵 목록 조회
+        List<FestivalMap> maps = festivalMapRepository.findByFestivalId(festivalId);
+
+        // 2. 현재 좌표가 속하는 맵 탐색 (직사각형 바운딩 박스 기준)
+        FestivalMap currentMap = maps.stream()
+                .filter(m -> isInsideMap(m, lat, lng))
+                .findFirst()
+                .orElse(null);
+
+        boolean isInside = currentMap != null;
+        Long currentMapId = isInside ? currentMap.getId() : null;
+        String h3Index = isInside ? h3.latLngToCellAddress(lat, lng, H3_RESOLUTION) : null;
+
+        // 3. 이전 위치 Redis에서 조회 후 카운트 감소
+        locationRedisRepository.getVisitorLocation(uuid).ifPresent(prev -> {
+            String[] parts = prev.split(":");
+            if (parts.length == 2) {
+                Long prevMapId = Long.parseLong(parts[0]);
+                String prevH3 = parts[1];
+                locationRedisRepository.decrementCell(prevMapId, prevH3);
+            }
+        });
+
+        // 4. 현재 위치 저장 및 카운트 증가
+        if (isInside) {
+            locationRedisRepository.saveVisitorLocation(uuid, currentMapId, h3Index);
+            locationRedisRepository.incrementCell(currentMapId, h3Index);
+        } else {
+            locationRedisRepository.deleteVisitorLocation(uuid);
+        }
+
+        return new VisitorLocationDTO.LocationUpdateResponse(
+                isInside, currentMapId, LOCATION_UPDATE_INTERVAL);
+    }
+
+    // 직사각형 바운딩 박스 내부 여부 판별
+    private boolean isInsideMap(FestivalMap map, double lat, double lng) {
+        if (map.getSouthWestLat() == null) return false;
+        return lat >= map.getSouthWestLat() && lat <= map.getNorthEastLat()
+                && lng >= map.getSouthWestLon() && lng <= map.getNorthEastLon();
+    }
+}

--- a/src/main/java/com/waglewagle/server/domain/visitor/service/VisitorLocationService.java
+++ b/src/main/java/com/waglewagle/server/domain/visitor/service/VisitorLocationService.java
@@ -1,4 +1,4 @@
-package com.waglewagle.server.domain.visitor.repository;
+package com.waglewagle.server.domain.visitor.service;
 
 import com.uber.h3core.H3Core;
 import com.waglewagle.server.domain.festivalMap.entity.FestivalMap;
@@ -33,10 +33,8 @@ public class VisitorLocationService {
         double lat = request.lat();
         double lng = request.lng();
 
-        // 1. 축제에 속한 맵 목록 조회
         List<FestivalMap> maps = festivalMapRepository.findByFestivalId(festivalId);
 
-        // 2. 현재 좌표가 속하는 맵 탐색 (직사각형 바운딩 박스 기준)
         FestivalMap currentMap = maps.stream()
                 .filter(m -> isInsideMap(m, lat, lng))
                 .findFirst()
@@ -44,23 +42,16 @@ public class VisitorLocationService {
 
         boolean isInside = currentMap != null;
         Long currentMapId = isInside ? currentMap.getId() : null;
-        String h3Index = isInside ? h3.latLngToCellAddress(lat, lng, H3_RESOLUTION) : null;
 
-        // 3. 이전 위치 Redis에서 조회 후 카운트 감소
-        locationRedisRepository.getVisitorLocation(uuid).ifPresent(prev -> {
-            String[] parts = prev.split(":");
-            if (parts.length == 2) {
-                Long prevMapId = Long.parseLong(parts[0]);
-                String prevH3 = parts[1];
-                locationRedisRepository.decrementCell(prevMapId, prevH3);
-            }
-        });
-
-        // 4. 현재 위치 저장 및 카운트 증가
         if (isInside) {
+            // H3 인덱스 생성
+            String h3Index = h3.latLngToCellAddress(lat, lng, H3_RESOLUTION);
+
+            // 핵심: 그냥 저장만 함. 30초 TTL이 알아서 갱신됨.
+            // 이전 위치를 찾아 뺄 필요가 없음! (다음 집계 때 자동으로 반영됨)
             locationRedisRepository.saveVisitorLocation(uuid, currentMapId, h3Index);
-            locationRedisRepository.incrementCell(currentMapId, h3Index);
         } else {
+            // 구역 밖이면 세션 삭제
             locationRedisRepository.deleteVisitorLocation(uuid);
         }
 

--- a/src/main/java/com/waglewagle/server/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/waglewagle/server/global/apiPayload/code/GeneralErrorCode.java
@@ -19,7 +19,10 @@ public enum GeneralErrorCode implements BaseErrorCode{
     LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH4000", "로그인이 필요한 기능입니다."),
 
     // USER 관련 에러
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4000", "해당하는 사용자가 존재하지 않습니다.");
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4000", "해당하는 사용자가 존재하지 않습니다."),
+
+    // MAP 관련 에러
+    MAP_NOT_FOUND(HttpStatus.BAD_REQUEST, "MAP4000", "해당하는 축제 지도가 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/waglewagle/server/global/redis/config/RedisConfig.java
+++ b/src/main/java/com/waglewagle/server/global/redis/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.waglewagle.server.global.redis.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory factory) {
+        return new StringRedisTemplate(factory);
+    }
+}

--- a/src/main/java/com/waglewagle/server/global/redis/repository/LocationRedisRepository.java
+++ b/src/main/java/com/waglewagle/server/global/redis/repository/LocationRedisRepository.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Redis 키 구조
@@ -21,60 +22,33 @@ import java.util.Set;
 public class LocationRedisRepository {
 
     private final StringRedisTemplate redisTemplate;
-
     private static final Duration VISITOR_TTL = Duration.ofSeconds(30);
+    private static final String VISITOR_KEY_PREFIX = "visitor:";
     private static final String VISITOR_KEY = "visitor:%s:location";
-    private static final String CELL_KEY = "map:%d:cell:%s";
-    private static final String CELL_PATTERN = "map:%d:cell:*";
 
-    // 방문자 이전 위치 조회
-    public Optional<String> getVisitorLocation(String uuid) {
-        String value = redisTemplate.opsForValue().get(VISITOR_KEY.formatted(uuid));
-        return Optional.ofNullable(value);
-    }
-
-    // 방문자 위치 저장 (TTL 갱신)
+    // 1. 방문자 위치 저장
     public void saveVisitorLocation(String uuid, Long mapId, String h3Index) {
         String key = VISITOR_KEY.formatted(uuid);
         String value = mapId + ":" + h3Index;
         redisTemplate.opsForValue().set(key, value, VISITOR_TTL);
     }
 
-    // 방문자 위치 키 삭제
+    // 2. 방문자 위치 삭제
     public void deleteVisitorLocation(String uuid) {
         redisTemplate.delete(VISITOR_KEY.formatted(uuid));
     }
 
-    // 셀 카운트 증가
-    public void incrementCell(Long mapId, String h3Index) {
-        String key = CELL_KEY.formatted(mapId, h3Index);
-        redisTemplate.opsForValue().increment(key);
-    }
-
-    // 셀 카운트 감소 (0 이하면 키 삭제)
-    public void decrementCell(Long mapId, String h3Index) {
-        String key = CELL_KEY.formatted(mapId, h3Index);
-        Long count = redisTemplate.opsForValue().decrement(key);
-        if (count != null && count <= 0) {
-            redisTemplate.delete(key);
-        }
-    }
-
-    // 맵의 전체 셀 목록 조회
+    // 3. 실시간으로 살아있는 키들을 전수조사해서 카운트 계산
     public Map<String, Integer> getCellCounts(Long mapId) {
-        String pattern = CELL_PATTERN.formatted(mapId);
-        Set<String> keys = redisTemplate.keys(pattern);
+        // "visitor:*:location" 패턴의 모든 키를 가져옴
+        Set<String> keys = redisTemplate.keys(VISITOR_KEY_PREFIX + "*:location");
         if (keys == null || keys.isEmpty()) return Map.of();
 
-        Map<String, Integer> result = new HashMap<>();
-        for (String key : keys) {
-            String value = redisTemplate.opsForValue().get(key);
-            if (value != null) {
-                // 키에서 h3Index 추출: "map:{mapId}:cell:{h3Index}"
-                String h3Index = key.substring(key.lastIndexOf(":") + 1);
-                result.put(h3Index, Integer.parseInt(value));
-            }
-        }
-        return result;
+        // 맵 아이디 필터링 및 H3 인덱스별 카운팅
+        return keys.stream()
+                .map(key -> redisTemplate.opsForValue().get(key))
+                .filter(value -> value != null && value.startsWith(mapId + ":"))
+                .map(value -> value.split(":")[1]) // "mapId:h3Index"에서 h3Index 추출
+                .collect(Collectors.groupingBy(h3 -> h3, Collectors.summingInt(e -> 1)));
     }
 }

--- a/src/main/java/com/waglewagle/server/global/redis/repository/LocationRedisRepository.java
+++ b/src/main/java/com/waglewagle/server/global/redis/repository/LocationRedisRepository.java
@@ -1,0 +1,80 @@
+package com.waglewagle.server.global.redis.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Redis 키 구조
+ * 방문자 위치: visitor:{uuid}:location → {mapId}:{h3Index} (TTL 30초)
+ * 셀 카운트: map:{mapId}:cell:{h3Index} → 인원 수 (String, incr/decr)
+ * **/
+
+@Repository
+@RequiredArgsConstructor
+public class LocationRedisRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final Duration VISITOR_TTL = Duration.ofSeconds(30);
+    private static final String VISITOR_KEY = "visitor:%s:location";
+    private static final String CELL_KEY = "map:%d:cell:%s";
+    private static final String CELL_PATTERN = "map:%d:cell:*";
+
+    // 방문자 이전 위치 조회
+    public Optional<String> getVisitorLocation(String uuid) {
+        String value = redisTemplate.opsForValue().get(VISITOR_KEY.formatted(uuid));
+        return Optional.ofNullable(value);
+    }
+
+    // 방문자 위치 저장 (TTL 갱신)
+    public void saveVisitorLocation(String uuid, Long mapId, String h3Index) {
+        String key = VISITOR_KEY.formatted(uuid);
+        String value = mapId + ":" + h3Index;
+        redisTemplate.opsForValue().set(key, value, VISITOR_TTL);
+    }
+
+    // 방문자 위치 키 삭제
+    public void deleteVisitorLocation(String uuid) {
+        redisTemplate.delete(VISITOR_KEY.formatted(uuid));
+    }
+
+    // 셀 카운트 증가
+    public void incrementCell(Long mapId, String h3Index) {
+        String key = CELL_KEY.formatted(mapId, h3Index);
+        redisTemplate.opsForValue().increment(key);
+    }
+
+    // 셀 카운트 감소 (0 이하면 키 삭제)
+    public void decrementCell(Long mapId, String h3Index) {
+        String key = CELL_KEY.formatted(mapId, h3Index);
+        Long count = redisTemplate.opsForValue().decrement(key);
+        if (count != null && count <= 0) {
+            redisTemplate.delete(key);
+        }
+    }
+
+    // 맵의 전체 셀 목록 조회
+    public Map<String, Integer> getCellCounts(Long mapId) {
+        String pattern = CELL_PATTERN.formatted(mapId);
+        Set<String> keys = redisTemplate.keys(pattern);
+        if (keys == null || keys.isEmpty()) return Map.of();
+
+        Map<String, Integer> result = new HashMap<>();
+        for (String key : keys) {
+            String value = redisTemplate.opsForValue().get(key);
+            if (value != null) {
+                // 키에서 h3Index 추출: "map:{mapId}:cell:{h3Index}"
+                String h3Index = key.substring(key.lastIndexOf(":") + 1);
+                result.put(h3Index, Integer.parseInt(value));
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  sql:
+    init:
+      mode: always
   application:
     name: wagle-server
   datasource:
@@ -8,7 +11,8 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
+    defer-datasource-initialization: true
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,24 @@
+-- 1. Festival
+INSERT INTO festival (name, description, poster_url, start_date, end_date, place_name, address, min_lat, max_lat, min_lon, max_lon)
+VALUES
+    ('2026 영남대 천마대동제', '영남대학교 봄 축제', 'poster_url_1', '2026-05-20 10:00:00', '2026-05-22 23:00:00', '영남대학교', '경산시 대학로 280', 35.820, 35.840, 128.740, 128.760),
+    ('대구 치맥 페스티벌', '전국 최대 규모 치맥 파티', 'poster_url_2', '2026-07-03 16:00:00', '2026-07-07 22:00:00', '두류공원', '대구 달서구 공원순환로 36', 35.845, 35.855, 128.550, 128.570),
+    ('서울 밤도깨비 야시장', '한강 야경과 함께하는 푸드트럭', 'poster_url_3', '2026-08-14 18:00:00', '2026-08-16 23:59:59', '반포한강공원', '서울 서초구 신반포로11길 40', 37.505, 37.515, 126.995, 127.005),
+    ('부산 불꽃축제', '광안리 해변의 화려한 밤하늘', 'poster_url_4', '2026-11-07 19:00:00', '2026-11-07 21:00:00', '광안리 해수욕장', '부산 수영구 광안해변로 219', 35.150, 35.160, 129.115, 129.125);
+
+-- 2. Festival Map
+INSERT INTO festival_map (festival_id, image_url, sequence, south_west_lat, south_west_lon, north_east_lat, north_east_lon)
+VALUES
+    (1, 'map_url_1_1', 1, 35.825, 128.745, 35.835, 128.755), -- 영남대
+    (2, 'map_url_2_1', 1, 35.848, 128.555, 35.852, 128.565), -- 대구
+    (3, 'map_url_3_1', 1, 37.508, 126.998, 37.512, 127.002), -- 서울
+    (4, 'map_url_4_1', 1, 35.153, 129.118, 35.157, 129.122); -- 부산
+
+-- 3. Time Table
+INSERT INTO time_table (festival_id, image_url, sequence)
+VALUES
+    (1, 'timetable_url_1_1', 1),
+    (1, 'timetable_url_1_2', 2),
+    (2, 'timetable_url_2_1', 1),
+    (3, 'timetable_url_3_1', 1),
+    (4, 'timetable_url_4_1', 1);

--- a/src/test/java/com/waglewagle/server/domain/festivalMap/CongestionServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/festivalMap/CongestionServiceTest.java
@@ -1,0 +1,147 @@
+package com.waglewagle.server.domain.festivalMap;
+
+import com.waglewagle.server.domain.festivalMap.dto.CongestionDTO;
+import com.waglewagle.server.domain.festivalMap.entity.FestivalMap;
+import com.waglewagle.server.domain.festivalMap.repository.FestivalMapRepository;
+import com.waglewagle.server.domain.festivalMap.service.CongestionService;
+import com.waglewagle.server.global.apiPayload.exception.GeneralException;
+import com.waglewagle.server.global.redis.repository.LocationRedisRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CongestionServiceTest {
+
+    @InjectMocks
+    private CongestionService congestionService;
+
+    @Mock
+    private FestivalMapRepository festivalMapRepository;
+
+    @Mock
+    private LocationRedisRepository locationRedisRepository;
+
+    private FestivalMap festivalMap;
+
+    @BeforeEach
+    void setUp() {
+        festivalMap = FestivalMap.builder()
+                .id(7L)
+                .imageUrl("https://example.com/map.png")
+                .sequence(1)
+                .southWestLat(35.8300)
+                .southWestLon(128.7550)
+                .northEastLat(35.8350)
+                .northEastLon(128.7600)
+                .build();
+    }
+
+    @Test
+    @DisplayName("정상 혼잡도 조회 - 셀별 레벨 분류 및 totalCount 합산 확인")
+    void getCongestion_success() {
+        // given
+        given(festivalMapRepository.findById(7L))
+                .willReturn(Optional.of(festivalMap));
+        given(locationRedisRepository.getCellCounts(7L))
+                .willReturn(Map.of(
+                        "cell_A", 3,   // level 1 (1~5명)
+                        "cell_B", 10,  // level 2 (6~15명)
+                        "cell_C", 20,  // level 3 (16~30명)
+                        "cell_D", 35   // level 4 (31명 이상)
+                ));
+
+        // when
+        CongestionDTO.CongestionResponse response = congestionService.getCongestion(7L);
+
+        // then
+        assertThat(response.totalCount()).isEqualTo(68);
+        assertThat(response.zones()).hasSize(4);
+
+        Map<String, Integer> levelMap = response.zones().stream()
+                .collect(Collectors.toMap(
+                        CongestionDTO.ZoneInfo::h3Index,
+                        CongestionDTO.ZoneInfo::level
+                ));
+
+        assertThat(levelMap.get("cell_A")).isEqualTo(1);
+        assertThat(levelMap.get("cell_B")).isEqualTo(2);
+        assertThat(levelMap.get("cell_C")).isEqualTo(3);
+        assertThat(levelMap.get("cell_D")).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("방문자가 없을 경우 zones 빈 리스트, totalCount=0 반환")
+    void getCongestion_empty() {
+        // given
+        given(festivalMapRepository.findById(7L))
+                .willReturn(Optional.of(festivalMap));
+        given(locationRedisRepository.getCellCounts(7L))
+                .willReturn(Map.of());
+
+        // when
+        CongestionDTO.CongestionResponse response = congestionService.getCongestion(7L);
+
+        // then
+        assertThat(response.totalCount()).isEqualTo(0);
+        assertThat(response.zones()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 mapId 조회 시 예외 발생")
+    void getCongestion_mapNotFound() {
+        // given
+        given(festivalMapRepository.findById(999L))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> congestionService.getCongestion(999L))
+                .isInstanceOf(GeneralException.class);
+    }
+
+    @Test
+    @DisplayName("혼잡도 레벨 경계값 확인 - 5명/6명/15명/16명/30명/31명")
+    void getCongestion_levelBoundary() {
+        // given
+        given(festivalMapRepository.findById(7L))
+                .willReturn(Optional.of(festivalMap));
+        given(locationRedisRepository.getCellCounts(7L))
+                .willReturn(Map.of(
+                        "cell_1", 5,   // level 1 최대
+                        "cell_2", 6,   // level 2 최소
+                        "cell_3", 15,  // level 2 최대
+                        "cell_4", 16,  // level 3 최소
+                        "cell_5", 30,  // level 3 최대
+                        "cell_6", 31   // level 4 최소
+                ));
+
+        // when
+        CongestionDTO.CongestionResponse response = congestionService.getCongestion(7L);
+
+        // then
+        Map<String, Integer> levelMap = response.zones().stream()
+                .collect(Collectors.toMap(
+                        CongestionDTO.ZoneInfo::h3Index,
+                        CongestionDTO.ZoneInfo::level
+                ));
+
+        assertThat(levelMap.get("cell_1")).isEqualTo(1);
+        assertThat(levelMap.get("cell_2")).isEqualTo(2);
+        assertThat(levelMap.get("cell_3")).isEqualTo(2);
+        assertThat(levelMap.get("cell_4")).isEqualTo(3);
+        assertThat(levelMap.get("cell_5")).isEqualTo(3);
+        assertThat(levelMap.get("cell_6")).isEqualTo(4);
+    }
+}

--- a/src/test/java/com/waglewagle/server/domain/visitor/VisitorLocationServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/visitor/VisitorLocationServiceTest.java
@@ -1,0 +1,166 @@
+package com.waglewagle.server.domain.visitor;
+
+import com.waglewagle.server.domain.festival.entity.Festival;
+import com.waglewagle.server.domain.festivalMap.entity.FestivalMap;
+import com.waglewagle.server.domain.festivalMap.repository.FestivalMapRepository;
+import com.waglewagle.server.domain.visitor.dto.VisitorLocationDTO;
+import com.waglewagle.server.domain.visitor.repository.VisitorLocationService;
+import com.waglewagle.server.global.redis.repository.LocationRedisRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class VisitorLocationServiceTest {
+
+    @InjectMocks
+    private VisitorLocationService visitorLocationService;
+
+    @Mock
+    private FestivalMapRepository festivalMapRepository;
+
+    @Mock
+    private LocationRedisRepository locationRedisRepository;
+
+    private Festival festival;
+    private FestivalMap festivalMap;
+
+    @BeforeEach
+    void setUp() {
+        festival = Festival.builder()
+                .id(1L)
+                .name("테스트 축제")
+                .description("테스트 축제 설명")
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .placeName("테스트 장소")
+                .address("대구광역시 수성구")
+                .build();
+
+        // 대구 수성못 근처 직사각형 구역으로 가정
+        festivalMap = FestivalMap.builder()
+                .id(7L)
+                .festival(festival)
+                .imageUrl("https://example.com/map.png")
+                .sequence(1)
+                .southWestLat(35.8300)
+                .southWestLon(128.7550)
+                .northEastLat(35.8350)
+                .northEastLon(128.7600)
+                .build();
+    }
+
+    @Test
+    @DisplayName("구역 내부 좌표 전송 시 isInside=true, currentMapId 반환")
+    void updateLocation_insideMap() {
+        // given
+        given(festivalMapRepository.findByFestivalId(1L))
+                .willReturn(List.of(festivalMap));
+        given(locationRedisRepository.getVisitorLocation("test-uuid"))
+                .willReturn(Optional.empty());
+
+        VisitorLocationDTO.LocationUpdateRequest request =
+                new VisitorLocationDTO.LocationUpdateRequest(35.8322, 128.7576);
+
+        // when
+        VisitorLocationDTO.LocationUpdateResponse response =
+                visitorLocationService.updateLocation(1L, "test-uuid", request);
+
+        // then
+        assertThat(response.isInside()).isTrue();
+        assertThat(response.currentMapId()).isEqualTo(7L);
+        assertThat(response.locationUpdateInterval()).isEqualTo(3000L);
+
+        // Redis 저장 및 카운트 증가 호출 확인
+        then(locationRedisRepository).should()
+                .saveVisitorLocation(eq("test-uuid"), eq(7L), anyString());
+
+        then(locationRedisRepository).should()
+                .incrementCell(eq(7L), anyString());
+    }
+
+    @Test
+    @DisplayName("구역 외부 좌표 전송 시 isInside=false, currentMapId=null 반환")
+    void updateLocation_outsideMap() {
+        // given
+        given(festivalMapRepository.findByFestivalId(1L))
+                .willReturn(List.of(festivalMap));
+        given(locationRedisRepository.getVisitorLocation("test-uuid"))
+                .willReturn(Optional.empty());
+
+        // 구역 밖 좌표
+        VisitorLocationDTO.LocationUpdateRequest request =
+                new VisitorLocationDTO.LocationUpdateRequest(37.5665, 126.9780);
+
+        // when
+        VisitorLocationDTO.LocationUpdateResponse response =
+                visitorLocationService.updateLocation(1L, "test-uuid", request);
+
+        // then
+        assertThat(response.isInside()).isFalse();
+        assertThat(response.currentMapId()).isNull();
+
+        then(locationRedisRepository).should().deleteVisitorLocation("test-uuid");
+        then(locationRedisRepository).should(never()).incrementCell(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("이전 위치가 있을 경우 이전 셀 카운트 감소 후 새 위치 저장")
+    void updateLocation_decrementPreviousCell() {
+        // given
+        given(festivalMapRepository.findByFestivalId(1L))
+                .willReturn(List.of(festivalMap));
+        // 이전 위치: 같은 맵의 다른 셀
+        given(locationRedisRepository.getVisitorLocation("test-uuid"))
+                .willReturn(Optional.of("7:8928308280fffff"));
+
+        VisitorLocationDTO.LocationUpdateRequest request =
+                new VisitorLocationDTO.LocationUpdateRequest(35.8322, 128.7576);
+
+        // when
+        visitorLocationService.updateLocation(1L, "test-uuid", request);
+
+        // then: 이전 셀 감소 확인
+        then(locationRedisRepository).should().decrementCell(7L, "8928308280fffff");
+        // 새 셀 증가 확인
+        then(locationRedisRepository).should().incrementCell(eq(7L), anyString());
+    }
+
+    @Test
+    @DisplayName("구역 내부에 있다가 외부로 나가면 이전 셀 카운트 감소")
+    void updateLocation_insideToOutside() {
+        // given
+        given(festivalMapRepository.findByFestivalId(1L))
+                .willReturn(List.of(festivalMap));
+        given(locationRedisRepository.getVisitorLocation("test-uuid"))
+                .willReturn(Optional.of("7:8928308280fffff"));
+
+        // 구역 밖 좌표
+        VisitorLocationDTO.LocationUpdateRequest request =
+                new VisitorLocationDTO.LocationUpdateRequest(37.5665, 126.9780);
+
+        // when
+        visitorLocationService.updateLocation(1L, "test-uuid", request);
+
+        // then
+        then(locationRedisRepository).should().decrementCell(7L, "8928308280fffff");
+        then(locationRedisRepository).should().deleteVisitorLocation("test-uuid");
+        then(locationRedisRepository).should(never()).incrementCell(anyLong(), anyString());
+    }
+}

--- a/src/test/java/com/waglewagle/server/domain/visitor/VisitorLocationServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/visitor/VisitorLocationServiceTest.java
@@ -4,7 +4,7 @@ import com.waglewagle.server.domain.festival.entity.Festival;
 import com.waglewagle.server.domain.festivalMap.entity.FestivalMap;
 import com.waglewagle.server.domain.festivalMap.repository.FestivalMapRepository;
 import com.waglewagle.server.domain.visitor.dto.VisitorLocationDTO;
-import com.waglewagle.server.domain.visitor.repository.VisitorLocationService;
+import com.waglewagle.server.domain.visitor.service.VisitorLocationService;
 import com.waglewagle.server.global.redis.repository.LocationRedisRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,15 +16,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class VisitorLocationServiceTest {
@@ -46,19 +43,13 @@ class VisitorLocationServiceTest {
         festival = Festival.builder()
                 .id(1L)
                 .name("테스트 축제")
-                .description("테스트 축제 설명")
                 .startDate(LocalDateTime.now().minusDays(1))
                 .endDate(LocalDateTime.now().plusDays(1))
-                .placeName("테스트 장소")
-                .address("대구광역시 수성구")
                 .build();
 
-        // 대구 수성못 근처 직사각형 구역으로 가정
         festivalMap = FestivalMap.builder()
                 .id(7L)
                 .festival(festival)
-                .imageUrl("https://example.com/map.png")
-                .sequence(1)
                 .southWestLat(35.8300)
                 .southWestLon(128.7550)
                 .northEastLat(35.8350)
@@ -67,13 +58,11 @@ class VisitorLocationServiceTest {
     }
 
     @Test
-    @DisplayName("구역 내부 좌표 전송 시 isInside=true, currentMapId 반환")
+    @DisplayName("구역 내부 좌표 전송 시 세션 저장 및 isInside=true 반환")
     void updateLocation_insideMap() {
         // given
         given(festivalMapRepository.findByFestivalId(1L))
                 .willReturn(List.of(festivalMap));
-        given(locationRedisRepository.getVisitorLocation("test-uuid"))
-                .willReturn(Optional.empty());
 
         VisitorLocationDTO.LocationUpdateRequest request =
                 new VisitorLocationDTO.LocationUpdateRequest(35.8322, 128.7576);
@@ -85,26 +74,19 @@ class VisitorLocationServiceTest {
         // then
         assertThat(response.isInside()).isTrue();
         assertThat(response.currentMapId()).isEqualTo(7L);
-        assertThat(response.locationUpdateInterval()).isEqualTo(3000L);
 
-        // Redis 저장 및 카운트 증가 호출 확인
+        // 핵심: 실시간 집계 방식에서는 saveVisitorLocation만 호출되면 됩니다.
         then(locationRedisRepository).should()
                 .saveVisitorLocation(eq("test-uuid"), eq(7L), anyString());
-
-        then(locationRedisRepository).should()
-                .incrementCell(eq(7L), anyString());
     }
 
     @Test
-    @DisplayName("구역 외부 좌표 전송 시 isInside=false, currentMapId=null 반환")
+    @DisplayName("구역 외부 좌표 전송 시 세션 삭제 및 isInside=false 반환")
     void updateLocation_outsideMap() {
         // given
         given(festivalMapRepository.findByFestivalId(1L))
                 .willReturn(List.of(festivalMap));
-        given(locationRedisRepository.getVisitorLocation("test-uuid"))
-                .willReturn(Optional.empty());
 
-        // 구역 밖 좌표
         VisitorLocationDTO.LocationUpdateRequest request =
                 new VisitorLocationDTO.LocationUpdateRequest(37.5665, 126.9780);
 
@@ -116,19 +98,17 @@ class VisitorLocationServiceTest {
         assertThat(response.isInside()).isFalse();
         assertThat(response.currentMapId()).isNull();
 
+        // 구역 밖이면 기존 세션을 삭제해야 함
         then(locationRedisRepository).should().deleteVisitorLocation("test-uuid");
-        then(locationRedisRepository).should(never()).incrementCell(anyLong(), anyString());
+        // 더 이상 increment 같은 메서드는 호출되지 않음
     }
 
     @Test
-    @DisplayName("이전 위치가 있을 경우 이전 셀 카운트 감소 후 새 위치 저장")
-    void updateLocation_decrementPreviousCell() {
+    @DisplayName("이미 위치 정보가 있어도 단순히 덮어쓰기(갱신) 처리")
+    void updateLocation_alreadyExists() {
         // given
         given(festivalMapRepository.findByFestivalId(1L))
                 .willReturn(List.of(festivalMap));
-        // 이전 위치: 같은 맵의 다른 셀
-        given(locationRedisRepository.getVisitorLocation("test-uuid"))
-                .willReturn(Optional.of("7:8928308280fffff"));
 
         VisitorLocationDTO.LocationUpdateRequest request =
                 new VisitorLocationDTO.LocationUpdateRequest(35.8322, 128.7576);
@@ -136,31 +116,9 @@ class VisitorLocationServiceTest {
         // when
         visitorLocationService.updateLocation(1L, "test-uuid", request);
 
-        // then: 이전 셀 감소 확인
-        then(locationRedisRepository).should().decrementCell(7L, "8928308280fffff");
-        // 새 셀 증가 확인
-        then(locationRedisRepository).should().incrementCell(eq(7L), anyString());
-    }
-
-    @Test
-    @DisplayName("구역 내부에 있다가 외부로 나가면 이전 셀 카운트 감소")
-    void updateLocation_insideToOutside() {
-        // given
-        given(festivalMapRepository.findByFestivalId(1L))
-                .willReturn(List.of(festivalMap));
-        given(locationRedisRepository.getVisitorLocation("test-uuid"))
-                .willReturn(Optional.of("7:8928308280fffff"));
-
-        // 구역 밖 좌표
-        VisitorLocationDTO.LocationUpdateRequest request =
-                new VisitorLocationDTO.LocationUpdateRequest(37.5665, 126.9780);
-
-        // when
-        visitorLocationService.updateLocation(1L, "test-uuid", request);
-
         // then
-        then(locationRedisRepository).should().decrementCell(7L, "8928308280fffff");
-        then(locationRedisRepository).should().deleteVisitorLocation("test-uuid");
-        then(locationRedisRepository).should(never()).incrementCell(anyLong(), anyString());
+        // 실시간 집계 방식은 이전 위치가 무엇이었든 상관없이 현재 위치를 저장만 하면 끝입니다.
+        then(locationRedisRepository).should()
+                .saveVisitorLocation(eq("test-uuid"), eq(7L), anyString());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Closes #61

## #️⃣ 작업 내용

### 신규 구현

**`POST /api/v1/festivals/{festivalId}/visitors/location` — 방문자 실시간 위치 전송**
- 요청 좌표(lat/lng)를 H3 Resolution 14 인덱스로 변환
- `FestivalMap`의 SW/NE 좌표 기반 직사각형 바운딩 박스로 구역 내부 여부 판별
- 구역 내부일 경우 `visitor:{uuid}:location` 키로 Redis에 저장 (TTL 30초 자동 갱신)
- 구역 외부일 경우 Redis 키 즉시 삭제

**`GET /api/v1/maps/{mapId}/congestion` — 구역별 실시간 혼잡도 조회**
- Redis의 `visitor:*:location` 키를 전수 조회하여 해당 Map에 속하는 방문자를 H3 셀 단위로 집계
- 셀당 절대 인원 기준 혼잡도 4단계 분류 `(1: 1~5명 / 2: 6~15명 / 3: 16~30명 / 4: 31명 이상)`
- 방문자 없는 셀은 응답에서 제외 (클라이언트에서 Clear 처리)

### 초기 설계 대비 설계 변경

**카운트 방식 변경: 셀별 카운터 키 → Redis 전수 집계**
- 초기 설계: `map:{mapId}:cell:{h3Index}` 키에 인원 수를 직접 증감
- 변경 후: 방문자 위치 키(`visitor:*:location`)를 실시간 집계하여 카운트 계산
- 변경 이유: 카운터 방식은 위치 갱신 시 이전 셀 감소 + 새 셀 증가를 원자적으로 처리해야 하는데, 네트워크 단절 등으로 감소 호출이 누락될 경우 카운트 정합성이 깨지는 문제가 있음. TTL 기반 전수 집계 방식은 키가 만료되면 자동으로 카운트에서 제외되므로 별도 보정 로직 없이 항상 정확한 값을 보장함.

### 인프라

- Redis 연동을 위한 `RedisConfig` 추가 (`LettuceConnectionFactory`, `StringRedisTemplate` 빈 등록)

### 단위 테스트

- `VisitorLocationServiceTest`: 구역 내부/외부 좌표, 이전 위치 처리, 구역 이탈 시나리오 검증
- `CongestionServiceTest`: 혼잡도 4단계 분류, 경계값, 빈 맵, 존재하지 않는 mapId 예외 검증

## #️⃣ 통합 테스트 결과

**DB 데이터 구축이 되지 않은 관계로 아직 진행하지 못했습니다. 추후 상황이 마련대는 대로 진행할 예정입니다.**

**`POST /api/v1/festivals/{festivalId}/visitors/location` — 구역 내부 좌표 전송**
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "isInside": true,
    "currentMapId": 1,
    "locationUpdateInterval": 3000
  }
}
```

**`POST /api/v1/festivals/{festivalId}/visitors/location` — 구역 외부 좌표 전송**
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "isInside": false,
    "currentMapId": null,
    "locationUpdateInterval": 3000
  }
}
```

**`GET /api/v1/maps/{mapId}/congestion` — 혼잡도 조회**
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "timestamp": 1777635022786,
    "totalCount": 1,
    "zones": [
      {
        "h3Index": "8e30c182aa11d0f",
        "count": 1,
        "level": 1
      }
    ]
  }
}
```

## #️⃣ 셀프 체크리스트
- [x] (Server) 로컬 환경에서 정상적으로 빌드되나요?
- [x] (Server) 예시 데이터를 통해 테스트를 마쳤나요?
- [ ] (Client) 화면이 깨지지 않고 렌더링되나요?
- [x] Swagger 문서가 최신화되었나요? (API 변경 시)
- [x] 코드 컨벤션을 준수했나요?

## #️⃣ 리뷰 요구사항
- `LocationRedisRepository.getCellCounts()`에서 `redisTemplate.keys()`를 사용하고 있는데, 운영 환경에서 방문자 수가 많아질 경우 성능 문제가 생길 수 있습니다. 현재 규모에서는 문제없다고 판단했지만, 추후 `SCAN` 명령어로 교체하는 것을 고려할 수 있습니다.
- TTL 30초 기준이 클라이언트 호출 간격(3초)에 비해 충분한지 검토 부탁드립니다.

## 📎 참고 자료 (Optional)
- [H3 Java 라이브러리](https://github.com/uber/h3-java)
- [H3 Resolution 테이블](https://h3geo.org/docs/core-library/restable/) — Res 14 평균 셀 면적 약 1.67㎡

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 축제 지도에서 각 구역의 혼잡도 현황을 실시간으로 조회할 수 있는 기능 추가
  * 방문객의 위치 정보를 통해 축제 구역 내외부 상태를 자동으로 감지하는 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->