### PR TITLE
fix: 엔티티 DB 컬럼명 매핑 수정 (#56)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
 
     // 5. Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -1,51 +1,52 @@
+# Wagle ERD
+
 ```mermaid
 erDiagram
-    FESTIVAL ||--o{ VISITOR : "has (접속자)"
-    FESTIVAL ||--|{ TIME_TABLE : "has (타임 테이블)"
-    FESTIVAL ||--|{ FESTIVAL_MAP : "has (지도)"
+    festival ||--o{ festival_map : "references"
+    festival ||--o{ time_table : "references"
+    festival ||--o{ visitor : "references"
 
-		VISITOR {
-        varchar uuid PK "UUID"
-        bigint festival_id FK "현재 접속한 축제 ID"
-        boolean is_terms_agreed "동의 여부 (토큰 발급 기준)"
-        datetime created_at "최초 접속 시간"
-        datetime last_active_at "마지막 활동 시간"
-    }
-
-		FESTIVAL {
-        bigint id PK "축제 ID"
-        varchar name "축제 이름"
-        varchar description "축제 설명"
-        varchar poster_url "포스터 썸네일 URL"
-        datetime start_date "시작 일시"
-        datetime end_date "종료 일시"
-        varchar place_name "장소명"
-        varchar address "상세 주소"    
-            
-        %% 축제 허용 범위
-        double min_lat "최소 위도 (남쪽 끝)"
-        double max_lat "최대 위도 (북쪽 끝)"
-        double min_lon "최소 경도 (서쪽 끝)"
-        double max_lon "최대 경도 (동쪽 끝)"
+    festival {
+        bigint id PK
+        varchar_100 name "NOT_NULL"
+        varchar_500 description
+        varchar poster_image_url
+        datetime start_at "NOT_NULL"
+        datetime end_at "NOT_NULL"
+        varchar place_name "NOT_NULL"
+        varchar address "NOT_NULL"
+        double south_west_lat
+        double south_west_lon
+        double north_east_lat
+        double north_east_lon
     }
 
-    TIME_TABLE {
-        bigint id PK "타임 테이블 ID"
-        bigint festival_id FK "소속 축제 ID"
-        varchar image_url "이미지 URL"
-        int sequence "노출 순서"
+    festival_map {
+        bigint id PK
+        bigint festival_id FK
+        varchar_100 name "NOT_NULL"
+        varchar map_image_url "NOT_NULL"
+        int sequence "NOT_NULL"
+        double south_west_lat
+        double south_west_lon
+        double north_east_lat
+        double north_east_lon
     }
-    
-    FESTIVAL_MAP {
-        bigint id PK "지도 ID"
-        bigint festival_id FK "소속 축제 ID"
-        varchar image_url "이미지 URL"
-        int sequence "노출 순서"
-        
-        %% 이미지를 지도에 매핑하기 위한 좌표 (Ground Overlay용)
-        double south_west_lat "이미지 좌하단 위도"
-        double south_west_lon "이미지 좌하단 경도"
-        double north_east_lat "이미지 우상단 위도"
-        double north_east_lon "이미지 우상단 경도"
+
+    time_table {
+        bigint id PK
+        bigint festival_id FK
+        varchar_100 name "NOT_NULL"
+        int sequence "NOT_NULL"
+        varchar image_url "NOT_NULL"
     }
+
+    visitor {
+        varchar_36 uuid PK
+        bigint festival_id FK
+        tinyint is_terms_agreed "NOT_NULL"
+        datetime created_at
+        datetime last_active_at
+    }
+
 ```

--- a/docs/erd/sql_to_mermaid.py
+++ b/docs/erd/sql_to_mermaid.py
@@ -1,0 +1,190 @@
+import re
+from pathlib import Path
+
+SQL_PATH = "docs/erd/wagle.sql"
+ERD_PATH = "docs/erd.md"
+
+
+def parse_existing_labels(erd_path):
+    """기존 erd.md에서 관계 라벨을 추출하여 보존"""
+    labels = {}
+    path = Path(erd_path)
+    if not path.exists():
+        return labels
+    text = path.read_text(encoding="utf-8")
+    for m in re.finditer(r'(\w+)\s+\|\|--o\{\s+(\w+)\s*:\s*"([^"]+)"', text):
+        labels[(m.group(1), m.group(2))] = m.group(3)
+    return labels
+
+
+def normalize_type(raw_type):
+    """SQL 타입을 Mermaid용으로 변환"""
+    raw = raw_type.strip()
+    upper = raw.upper()
+
+    vm = re.match(r'VARCHAR\((\d+)\)', upper)
+    if vm:
+        length = vm.group(1)
+        return "varchar" if length == "255" else f"varchar_{length}"
+    if upper == "VARCHAR":
+        return "varchar"
+
+    if upper.startswith("DATETIME"):
+        return "datetime"
+
+    if upper.startswith("TINYINT"):
+        return "tinyint"
+
+    if upper.startswith("ENUM"):
+        return "enum"
+
+    base = re.match(r'(\w+)', upper)
+    return base.group(1).lower() if base else raw.lower()
+
+
+def parse_sql(sql_path):
+    """SQL 파싱 → 테이블 목록 + FK 관계"""
+    raw = Path(sql_path).read_text(encoding="utf-8")
+
+    raw = re.split(r'DELIMITER\s', raw, flags=re.IGNORECASE)[0]
+    raw = re.sub(r'--[^\n]*', '', raw)
+    raw = re.sub(r'/\*.*?\*/', '', raw, flags=re.DOTALL)
+    raw = re.sub(r'CREATE\s+INDEX\s+[^;]*;', '', raw, flags=re.IGNORECASE)
+
+    tables = {}
+    relationships = []
+
+    for m in re.finditer(
+        r'CREATE\s+TABLE\s+[`"]?(\w+)[`"]?\s*\((.*?)\)\s*(?:ENGINE|;)',
+        raw, re.IGNORECASE | re.DOTALL,
+    ):
+        tname = m.group(1)
+        body = m.group(2)
+
+        pk_m = re.search(r'PRIMARY\s+KEY\s*\(([^)]+)\)', body, re.IGNORECASE)
+        pk_cols = set()
+        if pk_m:
+            pk_cols = {c.strip().strip('`"') for c in pk_m.group(1).split(',')}
+
+        fk_map = {}
+        for fk_m in re.finditer(
+            r'FOREIGN\s+KEY\s*\(\s*[`"]?(\w+)[`"]?\s*\)\s*REFERENCES\s+[`"]?(\w+)[`"]?',
+            body, re.IGNORECASE,
+        ):
+            fk_col, parent = fk_m.group(1), fk_m.group(2)
+            fk_map[fk_col] = parent
+            relationships.append((parent, tname))
+
+        collapsed = body
+        while True:
+            merged = re.sub(r"(ENUM\s*\([^)]*?)\n\s*", r"\1 ", collapsed)
+            if merged == collapsed:
+                break
+            collapsed = merged
+
+        columns = []
+        for line in collapsed.split('\n'):
+            line = line.strip().rstrip(',')
+            if not line:
+                continue
+            if re.match(
+                r'(?:PRIMARY|CONSTRAINT|UNIQUE\s+KEY|KEY\s|INDEX|FOREIGN)',
+                line, re.IGNORECASE,
+            ):
+                continue
+
+            col_m = re.match(r'[`"]?(\w+)[`"]?\s+(.*)', line)
+            if not col_m:
+                continue
+
+            col_name = col_m.group(1)
+            rest = col_m.group(2)
+
+            if rest.upper().startswith('ENUM'):
+                depth, end = 0, 0
+                for i, c in enumerate(rest):
+                    if c == '(':
+                        depth += 1
+                    elif c == ')':
+                        depth -= 1
+                        if depth == 0:
+                            end = i + 1
+                            break
+                type_str = rest[:end]
+                after_type = rest[end:]
+            else:
+                type_m = re.match(r'(\w+(?:\([^)]*\))?)', rest)
+                if not type_m:
+                    continue
+                type_str = type_m.group(1)
+                after_type = rest[len(type_str):]
+
+            col_type = normalize_type(type_str)
+            is_not_null = bool(re.search(r'NOT\s+NULL', after_type, re.IGNORECASE))
+            is_unique = bool(re.search(r'\bUNIQUE\b', after_type, re.IGNORECASE))
+
+            flag = ""
+            annotation = ""
+            if col_name in pk_cols:
+                flag = "PK"
+            elif col_name in fk_map:
+                flag = "FK"
+                if is_unique:
+                    annotation = '"Unique"'
+            else:
+                parts = []
+                if is_not_null:
+                    parts.append("NOT_NULL")
+                if is_unique:
+                    parts.append("Unique")
+                if parts:
+                    annotation = f'"{", ".join(parts)}"'
+
+            entry = f"{col_type} {col_name}"
+            if flag:
+                entry += f" {flag}"
+            if annotation:
+                entry += f" {annotation}"
+            columns.append(entry)
+
+        tables[tname] = columns
+
+    relationships = list(dict.fromkeys(relationships))
+    return tables, relationships
+
+
+def generate_erd(tables, relationships, labels):
+    """erd.md 생성"""
+    lines = [
+        "# Wagle ERD",
+        "",
+        "```mermaid",
+        "erDiagram",
+    ]
+
+    for parent, child in relationships:
+        label = labels.get((parent, child), "references")
+        lines.append(f'    {parent} ||--o{{ {child} : "{label}"')
+
+    lines.append("")
+
+    for tname, cols in tables.items():
+        lines.append(f"    {tname} {{")
+        for col in cols:
+            lines.append(f"        {col}")
+        lines.append("    }")
+        lines.append("")
+
+    lines.append("```")
+    return "\n".join(lines) + "\n"
+
+
+if __name__ == "__main__":
+    print(f"[*] {SQL_PATH} 파싱 중...")
+
+    labels = parse_existing_labels(ERD_PATH)
+    tables, rels = parse_sql(SQL_PATH)
+    result = generate_erd(tables, rels, labels)
+
+    Path(ERD_PATH).write_text(result, encoding="utf-8")
+    print(f"[*] {ERD_PATH} 업데이트 완료 ({len(tables)}개 테이블, {len(rels)}개 관계)")

--- a/docs/erd/wagle.sql
+++ b/docs/erd/wagle.sql
@@ -1,0 +1,49 @@
+CREATE TABLE festival (
+    id              BIGINT          NOT NULL AUTO_INCREMENT,
+    name            VARCHAR(100)    NOT NULL,
+    description     VARCHAR(500),
+    poster_image_url VARCHAR(255),
+    start_at        DATETIME        NOT NULL,
+    end_at          DATETIME        NOT NULL,
+    place_name      VARCHAR(255)    NOT NULL,
+    address         VARCHAR(255)    NOT NULL,
+    south_west_lat  DOUBLE,
+    south_west_lon  DOUBLE,
+    north_east_lat  DOUBLE,
+    north_east_lon  DOUBLE,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE festival_map (
+    id              BIGINT          NOT NULL AUTO_INCREMENT,
+    festival_id     BIGINT          NOT NULL,
+    name            VARCHAR(100)    NOT NULL,
+    map_image_url   VARCHAR(255)    NOT NULL,
+    sequence        INT             NOT NULL,
+    south_west_lat  DOUBLE,
+    south_west_lon  DOUBLE,
+    north_east_lat  DOUBLE,
+    north_east_lon  DOUBLE,
+    PRIMARY KEY (id),
+    FOREIGN KEY (festival_id) REFERENCES festival(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE time_table (
+    id              BIGINT          NOT NULL AUTO_INCREMENT,
+    festival_id     BIGINT          NOT NULL,
+    name            VARCHAR(100)    NOT NULL,
+    sequence        INT             NOT NULL,
+    image_url       VARCHAR(255)    NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (festival_id) REFERENCES festival(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE visitor (
+    uuid            VARCHAR(36)     NOT NULL,
+    festival_id     BIGINT,
+    is_terms_agreed TINYINT(1)      NOT NULL,
+    created_at      DATETIME,
+    last_active_at  DATETIME,
+    PRIMARY KEY (uuid),
+    FOREIGN KEY (festival_id) REFERENCES festival(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/java/com/waglewagle/server/domain/festival/dto/FestivalDTO.java
+++ b/src/main/java/com/waglewagle/server/domain/festival/dto/FestivalDTO.java
@@ -41,8 +41,8 @@ public class FestivalDTO {
             return new FestivalSummary(
                     festival.getId(),
                     festival.getName(),
-                    festival.getPosterUrl(),
-                    calculateStatus(festival.getStartDate(), festival.getEndDate()),
+                    festival.getPosterImageUrl(),
+                    calculateStatus(festival.getStartAt(), festival.getEndAt()),
                     festival.getPlaceName()
             );
         }
@@ -82,9 +82,9 @@ public class FestivalDTO {
                     festival.getId(),
                     festival.getName(),
                     festival.getDescription(),
-                    festival.getPosterUrl(),
-                    festival.getStartDate(),
-                    festival.getEndDate(),
+                    festival.getPosterImageUrl(),
+                    festival.getStartAt(),
+                    festival.getEndAt(),
                     festival.getPlaceName(),
                     festival.getAddress()
             );

--- a/src/main/java/com/waglewagle/server/domain/festival/entity/Festival.java
+++ b/src/main/java/com/waglewagle/server/domain/festival/entity/Festival.java
@@ -25,31 +25,30 @@ public class Festival {
     @Column(length = 500)
     private String description;
 
-    @Column(name = "poster_url")
-    private String posterUrl;
+    @Column(name = "poster_image_url")
+    private String posterImageUrl;
 
-    @Column(name = "start_date", nullable = false)
-    private LocalDateTime startDate;
+    @Column(name = "start_at", nullable = false)
+    private LocalDateTime startAt;
 
-    @Column(name = "end_date", nullable = false)
-    private LocalDateTime endDate;
+    @Column(name = "end_at", nullable = false)
+    private LocalDateTime endAt;
 
     @Column(name = "place_name", nullable = false)
-    private String placeName; // 축제 대표 장소명
+    private String placeName;
 
     @Column(name = "address", nullable = false)
-    private String address;   // 상세 주소
+    private String address;
 
-    // --- 축제 허용 범위 (Geographical Bounds) ---
-    @Column(name = "min_lat")
-    private Double minLat;
+    @Column(name = "south_west_lat")
+    private Double southWestLat;
 
-    @Column(name = "max_lat")
-    private Double maxLat;
+    @Column(name = "south_west_lon")
+    private Double southWestLon;
 
-    @Column(name = "min_lon")
-    private Double minLon;
+    @Column(name = "north_east_lat")
+    private Double northEastLat;
 
-    @Column(name = "max_lon")
-    private Double maxLon;
+    @Column(name = "north_east_lon")
+    private Double northEastLon;
 }

--- a/src/main/java/com/waglewagle/server/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/waglewagle/server/domain/festival/repository/FestivalRepository.java
@@ -15,15 +15,15 @@ public interface FestivalRepository  extends JpaRepository<Festival, Long> {
     Page<Festival> findByNameContaining(String keyword, Pageable pageable);
 
     // 1순위: 개최 중 (시작일 <= 현재 <= 종료일) 중 시작일 최신순
-    @Query("SELECT f FROM Festival f WHERE f.startDate <= :now AND f.endDate >= :now ORDER BY f.startDate DESC")
+    @Query("SELECT f FROM Festival f WHERE f.startAt <= :now AND f.endAt >= :now ORDER BY f.startAt DESC")
     List<Festival> findOngoing(@Param("now") LocalDateTime now, Pageable pageable);
 
     // 2순위: 개최 예정 (현재 < 시작일) 중 시작일 제일 가까운 순
-    @Query("SELECT f FROM Festival f WHERE f.startDate > :now ORDER BY f.startDate ASC")
+    @Query("SELECT f FROM Festival f WHERE f.startAt > :now ORDER BY f.startAt ASC")
     List<Festival> findUpcoming(@Param("now") LocalDateTime now, Pageable pageable);
 
     // 3순위: 이미 종료 (종료일 < 현재) 중 종료일 제일 가까운 순
-    @Query("SELECT f FROM Festival f WHERE f.endDate < :now ORDER BY f.endDate DESC")
+    @Query("SELECT f FROM Festival f WHERE f.endAt < :now ORDER BY f.endAt DESC")
     List<Festival> findEnd(@Param("now") LocalDateTime now, Pageable pageable);
 
 }

--- a/src/main/java/com/waglewagle/server/domain/festivalMap/dto/FestivalMapDTO.java
+++ b/src/main/java/com/waglewagle/server/domain/festivalMap/dto/FestivalMapDTO.java
@@ -22,7 +22,7 @@ public class FestivalMapDTO {
             return new FestivalMapInfo(
                     entity.getSequence(),
                     entity.getId(),
-                    entity.getImageUrl(),
+                    entity.getMapImageUrl(),
                     new MapBounds(
                             new LatLng(entity.getSouthWestLat(), entity.getSouthWestLon()),
                             new LatLng(entity.getNorthEastLat(), entity.getNorthEastLon())

--- a/src/main/java/com/waglewagle/server/domain/festivalMap/entity/FestivalMap.java
+++ b/src/main/java/com/waglewagle/server/domain/festivalMap/entity/FestivalMap.java
@@ -23,8 +23,8 @@ public class FestivalMap {
     @Column(nullable = false, length = 100)
     private String name;
 
-    @Column(name = "image_url", nullable = false)
-    private String imageUrl;
+    @Column(name = "map_image_url", nullable = false)
+    private String mapImageUrl;
 
     @Column(nullable = false)
     private Integer sequence; // 노출 순서

--- a/src/test/java/com/waglewagle/server/domain/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/festival/service/FestivalServiceTest.java
@@ -39,9 +39,9 @@ class FestivalServiceTest {
         return Festival.builder()
                 .id(id)
                 .name(name)
-                .startDate(start)
-                .endDate(end)
-                .posterUrl("url")
+                .startAt(start)
+                .endAt(end)
+                .posterImageUrl("url")
                 .placeName("place")
                 .build();
     }

--- a/src/test/java/com/waglewagle/server/domain/festivalMap/CongestionServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/festivalMap/CongestionServiceTest.java
@@ -40,7 +40,7 @@ class CongestionServiceTest {
     void setUp() {
         festivalMap = FestivalMap.builder()
                 .id(7L)
-                .imageUrl("https://example.com/map.png")
+                .mapImageUrl("https://example.com/map.png")
                 .sequence(1)
                 .southWestLat(35.8300)
                 .southWestLon(128.7550)

--- a/src/test/java/com/waglewagle/server/domain/visitor/VisitorLocationServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/visitor/VisitorLocationServiceTest.java
@@ -43,8 +43,8 @@ class VisitorLocationServiceTest {
         festival = Festival.builder()
                 .id(1L)
                 .name("테스트 축제")
-                .startDate(LocalDateTime.now().minusDays(1))
-                .endDate(LocalDateTime.now().plusDays(1))
+                .startAt(LocalDateTime.now().minusDays(1))
+                .endAt(LocalDateTime.now().plusDays(1))
                 .build();
 
         festivalMap = FestivalMap.builder()

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;NON_KEYWORDS=value
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: never
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+jwt:
+  token:
+    secret-key: test-secret-key-must-be-very-long-and-secure-enough
+    expiration:
+      access: 604800000


### PR DESCRIPTION
## Summary

- `Festival` 엔티티 컬럼명을 실제 DB 스키마와 일치하도록 수정
  - `poster_url` → `poster_image_url`
  - `start_date` → `start_at`, `end_date` → `end_at`
  - `min_lat/lon`, `max_lat/lon` → `south_west_lat/lon`, `north_east_lat/lon`
- `FestivalMap` 엔티티 컬럼명 수정
  - `image_url` → `map_image_url`
- 관련 DTO, Repository JPQL 쿼리, 테스트 코드 일괄 반영
- `docs/erd/wagle.sql` DDL 작성 및 `docs/erd/sql_to_mermaid.py` 스크립트 추가
- `docs/erd.md` 수정된 컬럼명 반영하여 재생성
- `contextLoads` 테스트 환경 구성 (H2 인메모리 DB, Redis 환경변수 형식)
- `application-prod.yml`: `sql.init.mode=never` 추가 — 배포 시 `data.sql` 실행 방지 (실 데이터 보호)
- `data.sql`: 변경된 컬럼명 반영

Closes #56

## Test plan

- [x] `./gradlew clean build` 빌드 및 전체 테스트 통과 확인
- [ ] 배포 후 `/api/v1/festivals`, `/api/v1/festivals/{id}` 응답 정상 확인
- [ ] `/api/v1/festivals/{id}/maps` 지도 이미지 URL 정상 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)