### PR TITLE
fix: 엔티티 DB 컬럼명 매핑 수정 및 배포 안정화

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -73,4 +73,5 @@ jobs:
             export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
             docker image prune -af
             docker pull ${{ vars.DOCKERHUB_USERNAME }}/wagle-server:latest
-            docker compose -f infra/docker-compose.yml up -d --no-deps --force-recreate wagle-app
+            docker compose -f infra/docker-compose.yml -p wagle-server up -d --no-deps --force-recreate wagle-app
+            docker network connect wagle-server_wagle-network wagle-nginx || true


### PR DESCRIPTION
## Summary

- `Festival` 엔티티 컬럼명을 실제 DB 스키마와 일치하도록 수정
  - `poster_url` → `poster_image_url`
  - `start_date` → `start_at`, `end_date` → `end_at`
  - `min_lat/lon`, `max_lat/lon` → `south_west_lat/lon`, `north_east_lat/lon`
- `FestivalMap` 엔티티 컬럼명 수정 (`image_url` → `map_image_url`)
- 관련 DTO, Repository JPQL 쿼리, 테스트 코드 일괄 반영
- `application-prod.yml`: `sql.init.mode=never` 추가 — 배포 시 `data.sql` 실행 방지
- `data.sql`: 변경된 컬럼명 반영
- `Festival.start_at`, `end_at`에 `columnDefinition = "DATETIME"` 명시 — Hibernate 6 DATETIME(6) 변환으로 인한 MySQL strict mode ALTER 에러 방지
- `contextLoads` 테스트 환경 구성 (H2 인메모리 DB, Redis 환경변수 형식)
- `docs/erd/wagle.sql` DDL 작성 및 `docs/erd/sql_to_mermaid.py` 스크립트 추가, `docs/erd.md` 재생성
- `_deploy.yml`: `-p wagle-server` 옵션 추가 및 nginx 네트워크 자동 연결 — 배포 시 502 재발 방지

Closes #56

## Test plan

- [x] `./gradlew clean build` 빌드 및 전체 테스트 통과 확인
- [x] 배포 후 `/health` 200 응답 확인
- [ ] `/api/v1/festivals`, `/api/v1/festivals/{id}` 응답 정상 확인
- [ ] `/api/v1/festivals/{id}/maps` 지도 이미지 URL 정상 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)