### PR TITLE
[fix] timetable에 로그인 로직 삭제

### DIFF
--- a/src/main/java/com/waglewagle/server/domain/festival/controller/FestivalController.java
+++ b/src/main/java/com/waglewagle/server/domain/festival/controller/FestivalController.java
@@ -34,7 +34,7 @@ public class FestivalController implements FestivalControllerDocs {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         return ApiResponse.onPageSuccess(GeneralSuccessCode.OK,
-                festivalService.getFastivals(keyword, page, size));
+                festivalService.getFestivals(keyword, page, size));
     }
 
     @GetMapping("/{festivalId}")

--- a/src/main/java/com/waglewagle/server/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/waglewagle/server/domain/festival/service/FestivalService.java
@@ -67,7 +67,7 @@ public class FestivalService {
         // -> 데이터 수가 적고 사용자가 적을 시 사용하면 유리
     }
 
-    public Page<FestivalDTO.FestivalSummary> getFastivals(
+    public Page<FestivalDTO.FestivalSummary> getFestivals(
             String keyword, int page, int size) {
 
         //slice도 고려(pageResponseDTO 변경 해야 함, 프론트와 백과 의논) -> 데이터가 많을 시 유리

--- a/src/main/java/com/waglewagle/server/domain/timeTable/controller/TimeTableController.java
+++ b/src/main/java/com/waglewagle/server/domain/timeTable/controller/TimeTableController.java
@@ -23,12 +23,11 @@ public class TimeTableController implements TimeTableControllerDocs {
     private final TimeTableService  timeTableService;
 
     @GetMapping("/{festivalId}/timetables")
-    @PreAuthorize("isAuthenticated()")
     @Override
     public ApiResponse<ListResponseDTO<TimeTableDTO.TimeTableInfo>> getTimeTables(
             @PathVariable Long festivalId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ApiResponse.onListSuccess(GeneralSuccessCode.OK,
-                timeTableService.getTimeTalbes(festivalId, userDetails));
+                timeTableService.getTimeTalbes(festivalId));
     }
 }

--- a/src/main/java/com/waglewagle/server/domain/timeTable/controller/TimeTableControllerDocs.java
+++ b/src/main/java/com/waglewagle/server/domain/timeTable/controller/TimeTableControllerDocs.java
@@ -44,7 +44,6 @@ public interface TimeTableControllerDocs {
             )
     })
     @GetMapping("/{festivalId}/timetables")
-    @PreAuthorize("isAuthenticated()")
     ApiResponse<ListResponseDTO<TimeTableDTO.TimeTableInfo>> getTimeTables(
             @PathVariable Long festivalId,
             @AuthenticationPrincipal CustomUserDetails userDetails);

--- a/src/main/java/com/waglewagle/server/domain/timeTable/service/TimeTableService.java
+++ b/src/main/java/com/waglewagle/server/domain/timeTable/service/TimeTableService.java
@@ -19,12 +19,7 @@ public class TimeTableService {
     private final TimeTableRepository timeTableRepository;
 
     public List<TimeTableDTO.TimeTableInfo> getTimeTalbes(
-            Long festivalId, CustomUserDetails userDetails) {
-
-        //만약 사용자 동의가 없다면 exception 발생 시킴
-        if (!userDetails.getVisitor().getIsTermsAgreed()) {
-            throw new GeneralException(GeneralErrorCode.UNAUTHORIZED);
-        }
+            Long festivalId) {
 
         //festivalId에 맞는 TimeTable을 찾고 sequence 기준으로 오름차순 정렬(여러 개를 찾음)
         List<TimeTable> timeTableList = timeTableRepository.findByFestivalIdOrderBySequenceAsc(festivalId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #72 

## #️⃣ 작업 내용

타임테이블 정보를 가져오는 로직에서 로그인 부분을 삭제했습니다.

## #️⃣ 테스트 결과

통합 테스트 실행 결과 타임테이블 정보를 로그인 없이 제대로 가져오는 걸 확인했습니다.

## #️⃣ 셀프 체크리스트

- [x] (Server) 로컬 환경에서 정상적으로 빌드되나요?
- [x] (Server) 예시 데이터를 통해 테스트를 마쳤나요?
- [ ] (Client) 화면이 깨지지 않고 렌더링되나요?
- [x] Swagger 문서가 최신화되었나요? (API 변경 시)
- [x] 코드 컨벤션을 준수했나요?

## #️⃣ 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. (예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?)

## 📎 참고 자료 (Optional)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 페스티벌 검색 기능이 정상 작동하도록 수정되었습니다. 검색 키워드 유효성 검사가 추가되었습니다.

* **기능 개선**
  * 시간표 조회 기능이 인증 없이 접근 가능하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->