### PR TITLE
fix: 혼잡도 API 500 에러 수정 (Redis 연결 + CORS 설정)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -75,3 +75,4 @@ jobs:
             docker pull ${{ vars.DOCKERHUB_USERNAME }}/wagle-server:latest
             docker compose -f infra/docker-compose.yml -p wagle-server up -d --no-deps --force-recreate wagle-app
             docker network connect wagle-server_wagle-network wagle-nginx || true
+            docker network connect wagle-server_wagle-network wagle-redis || true

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -72,6 +72,7 @@ jobs:
             export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
             export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
             export REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
+            export SPRING_PROFILES_ACTIVE=${{ inputs.environment == 'staging' && 'prod,staging' || 'prod' }}
             docker image prune -af
             docker pull ${{ vars.DOCKERHUB_USERNAME }}/wagle-server:latest
             docker compose -f infra/docker-compose.yml -p wagle-server up -d --no-deps --force-recreate wagle-app

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -71,6 +71,7 @@ jobs:
             export DB_USERNAME=${{ vars.DB_USERNAME }}
             export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
             export JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
+            export REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
             docker image prune -af
             docker pull ${{ vars.DOCKERHUB_USERNAME }}/wagle-server:latest
             docker compose -f infra/docker-compose.yml -p wagle-server up -d --no-deps --force-recreate wagle-app

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - DB_USERNAME=${DB_USERNAME}
       - DB_PASSWORD=${DB_PASSWORD}
       - REDIS_HOST=wagle-redis
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
     depends_on:
       - wagle-redis

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - REDIS_HOST=wagle-redis
       - REDIS_PASSWORD=${REDIS_PASSWORD}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-prod}
     depends_on:
       - wagle-redis
     networks:

--- a/src/main/java/com/waglewagle/server/global/redis/config/RedisConfig.java
+++ b/src/main/java/com/waglewagle/server/global/redis/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
@@ -16,9 +17,16 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+    @Value("${spring.data.redis.password:}")
+    private String password;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        if (password != null && !password.isBlank()) {
+            config.setPassword(password);
+        }
+        return new LettuceConnectionFactory(config);
     }
 
     @Bean

--- a/src/main/java/com/waglewagle/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/waglewagle/server/global/security/config/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration

--- a/src/main/java/com/waglewagle/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/waglewagle/server/global/security/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.waglewagle.server.global.security.jwt.JwtFilter;
 import com.waglewagle.server.global.security.jwt.JwtUtil;
 import com.waglewagle.server.global.security.userdetails.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -18,7 +19,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
 import java.util.List;
 
 @Configuration
@@ -26,6 +26,9 @@ import java.util.List;
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
 
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final JwtUtil jwtUtil;
@@ -74,11 +77,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // 허용할 프론트엔드 도메인
-        configuration.setAllowedOrigins(Arrays.asList(
-                "http://localhost:3000",
-                "https://wagle-client.vercel.app"
-        ));
+        configuration.setAllowedOrigins(allowedOrigins);
 
         // 허용할 HTTP 메서드 (GET, POST 등)
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));

--- a/src/main/java/com/waglewagle/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/waglewagle/server/global/security/config/SecurityConfig.java
@@ -28,7 +28,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    @Value("${cors.allowed-origins}")
+    @Value("#{'${cors.allowed-origins}'.split(',')}")
     private List<String> allowedOrigins;
 
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update # 초기 운영 환경이므로 update로 설정
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: false # 운영 환경에서 로그 부하를 줄이기 위해 false로 설정
@@ -21,6 +21,7 @@ spring:
       # 2. Redis 주소
       host: ${REDIS_HOST}
       port: 6379
+      password: ${REDIS_PASSWORD:}
 
 jwt:
   token:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,7 +21,7 @@ spring:
       # 2. Redis 주소
       host: ${REDIS_HOST}
       port: 6379
-      password: ${REDIS_PASSWORD:}
+      password: ${REDIS_PASSWORD}
 
 jwt:
   token:
@@ -41,3 +41,6 @@ springdoc:
 
 server:
   forward-headers-strategy: framework
+
+cors:
+  allowed-origins: http://localhost:3000,https://wagle-client.vercel.app

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -1,0 +1,2 @@
+cors:
+  allowed-origins: http://localhost:3000,https://wagle-client.vercel.app,http://172.30.1.73:3000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,6 @@ jwt:
     secret-key: ${JWT_SECRET_KEY:waglewagle-secret-key-must-be-very-long-and-secure-enough}
     expiration:
       access: 604800000
+
+cors:
+  allowed-origins: http://localhost:3000,https://wagle-client.vercel.app,http://172.30.1.73:3000

--- a/src/test/java/com/waglewagle/server/domain/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/festival/service/FestivalServiceTest.java
@@ -115,7 +115,7 @@ class FestivalServiceTest {
                 .thenReturn(page);
 
         // when
-        Page<FestivalDTO.FestivalSummary> result = festivalService.getFastivals("김밥", 0, 5);
+        Page<FestivalDTO.FestivalSummary> result = festivalService.getFestivals("김밥", 0, 5);
 
         // then
         assertEquals(1, result.getTotalElements());

--- a/src/test/java/com/waglewagle/server/domain/timeTable/service/TimeTableServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/timeTable/service/TimeTableServiceTest.java
@@ -3,10 +3,8 @@ package com.waglewagle.server.domain.timeTable.service;
 import com.waglewagle.server.domain.timeTable.dto.TimeTableDTO;
 import com.waglewagle.server.domain.timeTable.entity.TimeTable;
 import com.waglewagle.server.domain.timeTable.repository.TimeTableRepository;
-import com.waglewagle.server.domain.visitor.entity.Visitor; // Visitor 엔티티 패키지 경로 확인 필요
 import com.waglewagle.server.global.apiPayload.code.GeneralErrorCode;
 import com.waglewagle.server.global.apiPayload.exception.GeneralException;
-import com.waglewagle.server.global.security.userdetails.CustomUserDetails;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,24 +24,14 @@ class TimeTableServiceTest {
     @Mock
     private TimeTableRepository timeTableRepository;
 
-    @Mock
-    private CustomUserDetails userDetails;
-
-    @Mock
-    private Visitor visitor; // UserDetails 내부의 Visitor도 Mocking
-
     @InjectMocks
     private TimeTableService timeTableService;
 
     @Test
-    @DisplayName("타임테이블 조회: 약관 동의한 사용자가 조회 시 성공")
+    @DisplayName("타임테이블 조회: 정상 조회 성공")
     void getTimeTables_Success() {
         // given
         Long festivalId = 1L;
-
-        // Mock 설정: userDetails.getVisitor().getIsTermsAgreed() -> true
-        when(userDetails.getVisitor()).thenReturn(visitor);
-        when(visitor.getIsTermsAgreed()).thenReturn(true);
 
         TimeTable timeTable = TimeTable.builder()
                 .imageUrl("https://s3.image.com/test.jpg")
@@ -54,7 +42,7 @@ class TimeTableServiceTest {
                 .thenReturn(List.of(timeTable));
 
         // when
-        List<TimeTableDTO.TimeTableInfo> result = timeTableService.getTimeTalbes(festivalId, userDetails);
+        List<TimeTableDTO.TimeTableInfo> result = timeTableService.getTimeTalbes(festivalId);
 
         // then
         assertEquals(1, result.size());
@@ -63,39 +51,17 @@ class TimeTableServiceTest {
     }
 
     @Test
-    @DisplayName("타임테이블 조회: 약관 미동의 사용자가 조회 시 UNAUTHORIZED 예외 발생")
-    void getTimeTables_UnAuthorized() {
-        // given
-        Long festivalId = 1L;
-
-        // Mock 설정: userDetails.getVisitor().getIsTermsAgreed() -> false
-        when(userDetails.getVisitor()).thenReturn(visitor);
-        when(visitor.getIsTermsAgreed()).thenReturn(false);
-
-        // when & then
-        GeneralException exception = assertThrows(GeneralException.class, () ->
-                timeTableService.getTimeTalbes(festivalId, userDetails)
-        );
-        assertEquals(GeneralErrorCode.UNAUTHORIZED, exception.getCode());
-
-        // 예외가 발생했으므로 레포지토리는 호출되지 않아야 함
-        verify(timeTableRepository, never()).findByFestivalIdOrderBySequenceAsc(anyLong());
-    }
-
-    @Test
     @DisplayName("타임테이블 조회: 데이터가 없을 때 TIMETABLE_NOT_FOUND 예외 발생")
     void getTimeTables_NotFound() {
         // given
         Long festivalId = 1L;
-        when(userDetails.getVisitor()).thenReturn(visitor);
-        when(visitor.getIsTermsAgreed()).thenReturn(true);
 
         when(timeTableRepository.findByFestivalIdOrderBySequenceAsc(festivalId))
                 .thenReturn(Collections.emptyList());
 
         // when & then
         GeneralException exception = assertThrows(GeneralException.class, () ->
-                timeTableService.getTimeTalbes(festivalId, userDetails)
+                timeTableService.getTimeTalbes(festivalId)
         );
         assertEquals(GeneralErrorCode.TIMETABLE_NOT_FOUND, exception.getCode());
     }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,3 +22,6 @@ jwt:
     secret-key: test-secret-key-must-be-very-long-and-secure-enough
     expiration:
       access: 604800000
+
+cors:
+  allowed-origins: http://localhost:3000


### PR DESCRIPTION
## 개요
`/api/v1/maps/{id}/congestion` 500 에러 원인 파악 및 수정

## 변경 사항

### 1. Docker 네트워크 격리 문제 수정
- `docker compose -p wagle-server` 프로젝트명 고정으로 네트워크명 일관성 확보
- 배포 시 `wagle-nginx`, `wagle-redis`를 `wagle-server_wagle-network`에 자동 연결

### 2. Redis 인증(NOAUTH) 오류 수정
- `RedisConfig.java`: `RedisStandaloneConfiguration`으로 비밀번호 인증 지원
- `application-prod.yml`: `REDIS_PASSWORD` 환경변수 바인딩 추가
- `infra/docker-compose.yml`: `REDIS_PASSWORD` 환경변수 주입
- `_deploy.yml`: 배포 스크립트에 `REDIS_PASSWORD` export 추가

### 3. CORS 허용 출처 프로퍼티로 분리
- `SecurityConfig.java`: 허용 출처를 `cors.allowed-origins` 프로퍼티로 분리
- `application.yml`: `172.30.1.73:3000` 추가

### 4. 기타
- `Festival` 엔티티 `start_at`, `end_at`에 `columnDefinition = "DATETIME"` 명시
- prod 배포 시 `data.sql` 실행 방지 (`sql.init.mode: never`)

## 관련 이슈
Closes #56

## 테스트
- [ ] `/api/v1/maps/{id}/congestion` 200 응답 확인
- [ ] Redis 연결 정상 동작 확인
- [ ] CORS 허용 출처 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선**
  * Redis 비밀번호 인증 지원 추가
  * CORS 설정이 더 유연하게 구성 가능하도록 개선

* **인프라 업데이트**
  * 프로덕션 환경에서 데이터베이스 자동 스키마 업데이트 비활성화로 안정성 강화
  * Docker Compose 환경 설정 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->