### PR TITLE
fix: Redis 연결 및 CORS 설정 마무리

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -76,5 +76,5 @@ jobs:
             docker image prune -af
             docker pull ${{ vars.DOCKERHUB_USERNAME }}/wagle-server:latest
             docker compose -f infra/docker-compose.yml -p wagle-server up -d --no-deps --force-recreate wagle-app
-            docker network connect wagle-server_wagle-network wagle-nginx || true
-            docker network connect wagle-server_wagle-network wagle-redis || true
+            docker network connect infra_wagle-network wagle-nginx || true
+            docker network connect infra_wagle-network wagle-redis || true

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -75,6 +75,6 @@ jobs:
             export SPRING_PROFILES_ACTIVE=${{ inputs.environment == 'staging' && 'prod,staging' || 'prod' }}
             docker image prune -af
             docker pull ${{ vars.DOCKERHUB_USERNAME }}/wagle-server:latest
-            docker compose -f infra/docker-compose.yml -p wagle-server up -d --no-deps --force-recreate wagle-app
+            docker compose -f infra/docker-compose.yml up -d --no-deps --force-recreate wagle-app
             docker network connect infra_wagle-network wagle-nginx || true
             docker network connect infra_wagle-network wagle-redis || true


### PR DESCRIPTION
## 개요
PR #74 이후 추가 발견된 배포 문제 수정 및 CORS/보안 개선

## 변경 사항

### 1. Docker 컨테이너 재생성 문제 수정
- `-p wagle-server` 제거: 프로젝트명 불일치로 `--force-recreate`가 동작하지 않아 환경변수 변경이 컨테이너에 반영되지 않던 문제 수정

### 2. 네트워크 연결 대상 수정
- `wagle-nginx`, `wagle-redis` 연결 대상을 `wagle-server_wagle-network` → `infra_wagle-network`로 수정 (wagle-app의 실제 네트워크)

### 3. staging 프로파일 분리
- `application-staging.yml` 추가: staging 환경에서 dev IP(`172.30.1.73:3000`) CORS 허용
- 배포 시 `SPRING_PROFILES_ACTIVE=prod,staging` / `prod` 환경별 주입

### 4. CORS 및 보안 개선
- `SecurityConfig`: `@Value` SpEL `split(',')` 명시로 CORS origins 분리 보장
- `application-prod.yml`: `REDIS_PASSWORD` 기본값 제거 (미설정 시 기동 실패)
- `application-prod.yml`: prod용 CORS origins 추가 (dev IP 제외)

### 5. 테스트 코드 수정
- develop 싱크 후 서비스 시그니처 변경에 맞게 테스트 수정
- 테스트 환경 yml에 `cors.allowed-origins` 추가

## 관련 이슈
Closes #56

## 테스트
- [ ] `REDIS_PASSWORD` GitHub staging Secrets 설정 필요
- [ ] `/api/v1/maps/{id}/congestion` 200 응답 확인
- [ ] staging 프론트(`172.30.1.73:3000`) CORS 허용 확인