### PR TITLE
feat: 추천/목록 축제 응답에 startDate/endDate 날짜 필드 추가

### DIFF
--- a/src/main/java/com/waglewagle/server/domain/festival/dto/FestivalDTO.java
+++ b/src/main/java/com/waglewagle/server/domain/festival/dto/FestivalDTO.java
@@ -6,9 +6,6 @@ import java.time.LocalDateTime;
 
 public class FestivalDTO {
 
-    /**
-     * 축제 기간을 바탕으로 상태를 판별하는 도메인 로직입니다.
-     */
     private static String calculateStatus(LocalDateTime start, LocalDateTime end) {
         LocalDateTime now = LocalDateTime.now();
         if (now.isBefore(start)) return "UPCOMING";
@@ -31,19 +28,23 @@ public class FestivalDTO {
             String status,
 
             @Schema(description = "축제 대표 장소/랜드마크", example = "김천 사명대사공원")
-            String placeName
+            String placeName,
+
+            @Schema(description = "축제 시작 일시", example = "2025-09-27T08:00:00")
+            LocalDateTime startDate,
+
+            @Schema(description = "축제 종료 일시", example = "2025-10-15T22:00:00")
+            LocalDateTime endDate
     ) {
-        /**
-         * Entity -> DTO 변환 Mapper
-         * 현재 시간을 기준으로 축제의 진행 상태를 계산하여 매핑합니다. [cite: 10]
-         */
         public static FestivalSummary from(Festival festival) {
             return new FestivalSummary(
                     festival.getId(),
                     festival.getName(),
                     festival.getPosterImageUrl(),
-                    calculateStatus(festival.getStartAt(), festival.getEndAt()),
-                    festival.getPlaceName()
+                    calculateStatus(festival.getStartDate(), festival.getEndDate()),
+                    festival.getPlaceName(),
+                    festival.getStartDate(),
+                    festival.getEndDate()
             );
         }
     }
@@ -74,17 +75,14 @@ public class FestivalDTO {
             @Schema(description = "상세 주소", example = "경상북도 김천시 대항면")
             String address
     ) {
-        /**
-         * Entity -> Detail DTO 변환 Mapper
-         */
         public static FestivalDetail from(Festival festival) {
             return new FestivalDetail(
                     festival.getId(),
                     festival.getName(),
                     festival.getDescription(),
                     festival.getPosterImageUrl(),
-                    festival.getStartAt(),
-                    festival.getEndAt(),
+                    festival.getStartDate(),
+                    festival.getEndDate(),
                     festival.getPlaceName(),
                     festival.getAddress()
             );

--- a/src/main/java/com/waglewagle/server/domain/festival/entity/Festival.java
+++ b/src/main/java/com/waglewagle/server/domain/festival/entity/Festival.java
@@ -29,10 +29,10 @@ public class Festival {
     private String posterImageUrl;
 
     @Column(name = "start_at", nullable = false, columnDefinition = "DATETIME")
-    private LocalDateTime startAt;
+    private LocalDateTime startDate;
 
     @Column(name = "end_at", nullable = false, columnDefinition = "DATETIME")
-    private LocalDateTime endAt;
+    private LocalDateTime endDate;
 
     @Column(name = "place_name", nullable = false)
     private String placeName;

--- a/src/main/java/com/waglewagle/server/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/waglewagle/server/domain/festival/repository/FestivalRepository.java
@@ -15,15 +15,15 @@ public interface FestivalRepository  extends JpaRepository<Festival, Long> {
     Page<Festival> findByNameContaining(String keyword, Pageable pageable);
 
     // 1순위: 개최 중 (시작일 <= 현재 <= 종료일) 중 시작일 최신순
-    @Query("SELECT f FROM Festival f WHERE f.startAt <= :now AND f.endAt >= :now ORDER BY f.startAt DESC")
+    @Query("SELECT f FROM Festival f WHERE f.startDate <= :now AND f.endDate >= :now ORDER BY f.startDate DESC")
     List<Festival> findOngoing(@Param("now") LocalDateTime now, Pageable pageable);
 
     // 2순위: 개최 예정 (현재 < 시작일) 중 시작일 제일 가까운 순
-    @Query("SELECT f FROM Festival f WHERE f.startAt > :now ORDER BY f.startAt ASC")
+    @Query("SELECT f FROM Festival f WHERE f.startDate > :now ORDER BY f.startDate ASC")
     List<Festival> findUpcoming(@Param("now") LocalDateTime now, Pageable pageable);
 
     // 3순위: 이미 종료 (종료일 < 현재) 중 종료일 제일 가까운 순
-    @Query("SELECT f FROM Festival f WHERE f.endAt < :now ORDER BY f.endAt DESC")
+    @Query("SELECT f FROM Festival f WHERE f.endDate < :now ORDER BY f.endDate DESC")
     List<Festival> findEnd(@Param("now") LocalDateTime now, Pageable pageable);
 
 }

--- a/src/test/java/com/waglewagle/server/domain/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/festival/service/FestivalServiceTest.java
@@ -39,8 +39,8 @@ class FestivalServiceTest {
         return Festival.builder()
                 .id(id)
                 .name(name)
-                .startAt(start)
-                .endAt(end)
+                .startDate(start)
+                .endDate(end)
                 .posterImageUrl("url")
                 .placeName("place")
                 .build();

--- a/src/test/java/com/waglewagle/server/domain/visitor/VisitorLocationServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/visitor/VisitorLocationServiceTest.java
@@ -43,8 +43,8 @@ class VisitorLocationServiceTest {
         festival = Festival.builder()
                 .id(1L)
                 .name("테스트 축제")
-                .startAt(LocalDateTime.now().minusDays(1))
-                .endAt(LocalDateTime.now().plusDays(1))
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
                 .build();
 
         festivalMap = FestivalMap.builder()


### PR DESCRIPTION
## 개요
`/api/v1/festivals/recommendations` 등 축제 목록 조회 API 응답에 날짜 필드가 누락되어 추가

## 변경 사항
- `FestivalSummary`에 `startDate`, `endDate` 필드 추가
- `Festival` 엔티티 필드명 `startAt`/`endAt` → `startDate`/`endDate` 통일
- `FestivalDetail` 필드명도 동일하게 통일
- `FestivalRepository` JPQL 쿼리 필드명 수정
- 관련 테스트 코드 수정

## 관련 이슈
Closes #76

## 테스트
- [ ] `GET /api/v1/festivals/recommendations` 응답에 `startDate`, `endDate` 포함 확인
- [ ] `GET /api/v1/festivals/{id}` 상세 응답 정상 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 축제 시작/종료 날짜 필드명을 명확하게 정규화하여 API 응답 일관성을 개선했습니다.

* **Refactor**
  * 축제 데이터 조회 시 필터링 로직을 업데이트하여 진행 중, 예정된, 종료된 축제 구분을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->