### PR TITLE
feat: 축제 추천/목록 응답에 날짜 필드 추가 및 혼잡도 설정 수정

### DIFF
--- a/src/main/java/com/waglewagle/server/domain/festivalMap/dto/CongestionDTO.java
+++ b/src/main/java/com/waglewagle/server/domain/festivalMap/dto/CongestionDTO.java
@@ -24,7 +24,7 @@ public class CongestionDTO {
             @Schema(description = "구역 내 인원 수 (디버깅/상세용)", example = "15")
             int count,
 
-            @Schema(description = "혼잡도 레벨 (0:쾌적, 1:보통, 2:혼잡, 3:매우혼잡)", example = "2")
+            @Schema(description = "혼잡도 레벨 (0:쾌적, 1:보통, 2:혼잡, 3:매우혼잡)", example = "1")
             int level
     ) {}
 }

--- a/src/main/java/com/waglewagle/server/domain/festivalMap/service/CongestionService.java
+++ b/src/main/java/com/waglewagle/server/domain/festivalMap/service/CongestionService.java
@@ -44,9 +44,9 @@ public class CongestionService {
 
     // 혼잡도 4단계 (셀당 절대 인원 기준)
     private int calculateLevel(int count) {
-        if (count >= 31) return 4;
-        if (count >= 16) return 3;
-        if (count >= 6)  return 2;
-        return 1;
+        if (count >= 31) return 3;
+        if (count >= 16) return 2;
+        if (count >= 6)  return 1;
+        return 0;
     }
 }

--- a/src/main/java/com/waglewagle/server/domain/visitor/service/VisitorLocationService.java
+++ b/src/main/java/com/waglewagle/server/domain/visitor/service/VisitorLocationService.java
@@ -18,7 +18,7 @@ public class VisitorLocationService {
     private final LocationRedisRepository locationRedisRepository;
 
     private static final H3Core h3 = createH3();
-    private static final int H3_RESOLUTION = 14;
+    private static final int H3_RESOLUTION = 13;
     private static final long LOCATION_UPDATE_INTERVAL = 3000L;
 
     private static H3Core createH3() {

--- a/src/test/java/com/waglewagle/server/domain/festivalMap/CongestionServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/festivalMap/CongestionServiceTest.java
@@ -57,10 +57,10 @@ class CongestionServiceTest {
                 .willReturn(Optional.of(festivalMap));
         given(locationRedisRepository.getCellCounts(7L))
                 .willReturn(Map.of(
-                        "cell_A", 3,   // level 1 (1~5명)
-                        "cell_B", 10,  // level 2 (6~15명)
-                        "cell_C", 20,  // level 3 (16~30명)
-                        "cell_D", 35   // level 4 (31명 이상)
+                        "cell_A", 3,   // level 0 (0~5명)
+                        "cell_B", 10,  // level 1 (6~15명)
+                        "cell_C", 20,  // level 2 (16~30명)
+                        "cell_D", 35   // level 3 (31명 이상)
                 ));
 
         // when
@@ -76,10 +76,10 @@ class CongestionServiceTest {
                         CongestionDTO.ZoneInfo::level
                 ));
 
-        assertThat(levelMap.get("cell_A")).isEqualTo(1);
-        assertThat(levelMap.get("cell_B")).isEqualTo(2);
-        assertThat(levelMap.get("cell_C")).isEqualTo(3);
-        assertThat(levelMap.get("cell_D")).isEqualTo(4);
+        assertThat(levelMap.get("cell_A")).isEqualTo(0);
+        assertThat(levelMap.get("cell_B")).isEqualTo(1);
+        assertThat(levelMap.get("cell_C")).isEqualTo(2);
+        assertThat(levelMap.get("cell_D")).isEqualTo(3);
     }
 
     @Test
@@ -137,11 +137,11 @@ class CongestionServiceTest {
                         CongestionDTO.ZoneInfo::level
                 ));
 
-        assertThat(levelMap.get("cell_1")).isEqualTo(1);
-        assertThat(levelMap.get("cell_2")).isEqualTo(2);
-        assertThat(levelMap.get("cell_3")).isEqualTo(2);
-        assertThat(levelMap.get("cell_4")).isEqualTo(3);
-        assertThat(levelMap.get("cell_5")).isEqualTo(3);
-        assertThat(levelMap.get("cell_6")).isEqualTo(4);
+        assertThat(levelMap.get("cell_1")).isEqualTo(0);
+        assertThat(levelMap.get("cell_2")).isEqualTo(1);
+        assertThat(levelMap.get("cell_3")).isEqualTo(1);
+        assertThat(levelMap.get("cell_4")).isEqualTo(2);
+        assertThat(levelMap.get("cell_5")).isEqualTo(2);
+        assertThat(levelMap.get("cell_6")).isEqualTo(3);
     }
 }


### PR DESCRIPTION
## Summary

- 축제 추천/목록 API 응답에 `startDate`, `endDate` 필드 추가 (타입: `LocalDate`, 시간 제거)
- 혼잡도 레벨을 1~4에서 0~3으로 변경 (0: 쾌적, 1: 보통, 2: 혼잡, 3: 매우혼잡)
- H3 resolution 14 → 13으로 변경 (셀 크기 확대, 약 6m² → 44m²)
- 방문자 위치 Redis TTL 30초 → 2분으로 연장 (일시적 네트워크 단절 및 GPS 오차 보정)
- staging 프로파일 분리 및 SPRING_PROFILES_ACTIVE 환경별 주입
- docker compose 관련 인프라 버그 수정 (컨테이너 재생성, 네트워크 연결)
- CORS origins SpEL 분리 및 REDIS_PASSWORD 필수화

Closes #76

## Test Plan

- [ ] `GET /api/v1/festivals` 응답에 `startDate`, `endDate` 포함 확인
- [ ] `GET /api/v1/festivals/recommendations` 응답에 `startDate`, `endDate` 포함 확인
- [ ] 혼잡도 API 응답 level 값이 0~3 범위인지 확인
- [ ] 위치 전송 후 2분 이내 혼잡도에 반영되는지 확인
- [ ] `CongestionServiceTest` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)