### PR TITLE
검색이 축제 이름, 장소와 매칭되도록 로직 수정

### DIFF
--- a/src/main/java/com/waglewagle/server/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/waglewagle/server/domain/festival/repository/FestivalRepository.java
@@ -12,6 +12,9 @@ import java.util.List;
 
 public interface FestivalRepository  extends JpaRepository<Festival, Long> {
 
+    @Query("SELECT DISTINCT f FROM Festival f WHERE LOWER(f.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(f.placeName) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    Page<Festival> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
     Page<Festival> findByNameContaining(String keyword, Pageable pageable);
 
     // 1순위: 개최 중 (시작일 <= 현재 <= 종료일) 중 시작일 최신순

--- a/src/main/java/com/waglewagle/server/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/waglewagle/server/domain/festival/service/FestivalService.java
@@ -80,8 +80,8 @@ public class FestivalService {
         //페이징 정보를 담기 사용(page 사용을 위해 필수)
         Pageable pageable = PageRequest.of(page, size);
 
-        //데이터를 page 형식으로 찾음, keyword가 축제 이름에 들어가는 걸 찾음
-        Page<Festival> festivalPage = festivalRepository.findByNameContaining(keyword, pageable);
+        //데이터를 page 형식으로 찾음, keyword가 축제 이름과 장소에 들어가는 걸 찾음
+        Page<Festival> festivalPage = festivalRepository.searchByKeyword(keyword, pageable);
 
         //데이터가 없을 시 exception을 발생 시킴
         if (festivalPage.isEmpty()) {

--- a/src/main/java/com/waglewagle/server/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/waglewagle/server/domain/festival/service/FestivalService.java
@@ -73,7 +73,7 @@ public class FestivalService {
         //slice도 고려(pageResponseDTO 변경 해야 함, 프론트와 백과 의논) -> 데이터가 많을 시 유리
 
         //keyword가 null일 경우 어떻게 하는가?(백, 프론트와 의논)
-        if(keyword == null || keyword.isEmpty()) {
+        if(keyword == null || keyword.trim().isEmpty()) {
             throw new GeneralException(GeneralErrorCode.KEYWORD_BAD_REQUEST);
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #80 

## #️⃣ 작업 내용

- **복합 검색 기능 도입 (이름 + 장소명)**
  - 기존의 축제 이름(`Title`) 기반 검색에서 확장하여, 장소명(`Location`) 필드도 함께 매칭되도록 검색 로직을 개선했습니다. 
  - Repository에 `DISTINCT` 키워드를 적용하여 이름과 장소에 검색어가 모두 포함되더라도 데이터가 중복 반환(뻥튀기)되는 현상을 해결했습니다.
- **검색 결과 공백 예외 처리 명확화**
  - 사용자가 검색어를 입력했으나 일치하는 축제 데이터가 없을 경우(`Page.isEmpty()`), 빈 페이지 대신 `FESTIVAL_NOT_FOUND` 커스텀 예외를 명확하게 발생시키도록 `FestivalService` 로직을 보완했습니다.
- **검색어 유효성 검사 추가**
  - 검색어가 `null`이거나 공백(`trim()`)만 입력된 채로 요청이 들어올 경우 `KEYWORD_BAD_REQUEST` 예외를 던져 잘못된 요청을 차단했습니다. -> 이건 문제 없이 swagger로 잘 돌아가는 걸 확인했습니다.

## #️⃣ 테스트 결과

#### 1.  검색 시 맞는 축제가 있을 때
``` json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "content": [
      {
        "id": 1,
        "name": "2026 영남대 천마대동제",
        "posterUrl": "poster_url_1",
        "status": "UPCOMING",
        "placeName": "영남대학교",
        "startDate": "2026-05-20",
        "endDate": "2026-05-22"
      }
    ],
    "totalPage": 1,
    "totalElements": 1,
    "size": 10,
    "page": 1,
    "first": true,
    "last": true
  }
}
```

#### 2. 검색 시 맞는 축제가 없을 때
``` json
{
  "isSuccess": false,
  "code": "FESTIVAL4000",
  "message": "해당 축제를 찾을 수 없습니다.",
  "result": null
}
```
## #️⃣ 셀프 체크리스트

- [x] (Server) 로컬 환경에서 정상적으로 빌드되나요?
- [x] (Server) 예시 데이터를 통해 테스트를 마쳤나요?
- [ ] (Client) 화면이 깨지지 않고 렌더링되나요?
- [x] Swagger 문서가 최신화되었나요? (API 변경 시)
- [x] 코드 컨벤션을 준수했나요?

## #️⃣ 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. (예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?)

## 📎 참고 자료 (Optional)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 축제 검색 개선: 축제 이름과 장소명을 포함한 키워드 검색이 지원됩니다. 사용자는 이제 축제명이나 개최 장소를 입력하여 관련 축제를 더욱 편리하게 검색할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wagle-project/wagle-server/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->