### PR TITLE
[Refactor] TTL 2분 + KEYS 명령어를 SCAN 방식으로 변경

### DIFF
--- a/src/main/java/com/waglewagle/server/global/redis/repository/LocationRedisRepository.java
+++ b/src/main/java/com/waglewagle/server/global/redis/repository/LocationRedisRepository.java
@@ -1,15 +1,19 @@
 package com.waglewagle.server.global.redis.repository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Redis 키 구조
@@ -22,7 +26,8 @@ import java.util.stream.Collectors;
 public class LocationRedisRepository {
 
     private final StringRedisTemplate redisTemplate;
-    private static final Duration VISITOR_TTL = Duration.ofSeconds(30);
+    // 학생회 요청으로 만료 시간을 기존 30초에서 2분(120초)으로 연장
+    private static final Duration VISITOR_TTL = Duration.ofMinutes(2);
     private static final String VISITOR_KEY_PREFIX = "visitor:";
     private static final String VISITOR_KEY = "visitor:%s:location";
 
@@ -40,9 +45,25 @@ public class LocationRedisRepository {
 
     // 3. 실시간으로 살아있는 키들을 전수조사해서 카운트 계산
     public Map<String, Integer> getCellCounts(Long mapId) {
-        // "visitor:*:location" 패턴의 모든 키를 가져옴
-        Set<String> keys = redisTemplate.keys(VISITOR_KEY_PREFIX + "*:location");
-        if (keys == null || keys.isEmpty()) return Map.of();
+        // "visitor:*:location" 패턴의 모든 키를 가져옴 (KEYS 대신 안전한 SCAN 방식으로 변경)
+        Set<String> keys = new HashSet<>();
+        ScanOptions options = ScanOptions.scanOptions()
+                .match(VISITOR_KEY_PREFIX + "*:location")
+                .count(1000) // 한 번에 1000개씩 쪼개서 조회 (레디스 블로킹 방지)
+                .build();
+
+        redisTemplate.execute((RedisCallback<Void>) connection -> {
+            try (Cursor<byte[]> cursor = connection.scan(options)) {
+                while (cursor.hasNext()) {
+                    keys.add(new String(cursor.next(), StandardCharsets.UTF_8));
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Redis SCAN 실행 중 예외 발생", e);
+            }
+            return null;
+        });
+
+        if (keys.isEmpty()) return Map.of();
 
         // 맵 아이디 필터링 및 H3 인덱스별 카운팅
         return keys.stream()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #82

## #️⃣ 작업 내용

학생회 요구사항 변경(이탈 유저 혼잡도 잔상 유지) 반영 및 대용량 트래픽 대비 레디스 안정성 확보를 위한 리팩토링 작업을 진행했습니다.

* **방문자 위치 만료 시간(TTL) 연장**
  * 유저가 앱을 종료하더라도 실제 축제 현장 인파에 머물러 있는 상황을 반영하기 위해, `LocationRedisRepository`의 `VISITOR_TTL`을 기존 30초에서 2분(`Duration.ofMinutes(2)`)으로 변경했습니다.
  * 이를 통해 앱 종료 후에도 2분간 혼잡도 카운트가 유지되는 효과를 냅니다.


* **실시간 카운트 집계 로직 성능 개선 (`KEYS` ➡️ `SCAN`)**
  * TTL이 4배 연장됨에 따라 레디스 내 상주하는 키의 개수가 크게 증가하게 됩니다.
  * 싱글 스레드 기반 레디스의 블로킹 장애를 예방하기 위해, 기존의 `redisTemplate.keys()` 전수조사 방식을 `ScanOptions`와 `Cursor`를 활용한 **논블로킹 분할 조회(`SCAN`) 방식**으로 안전하게 리팩토링했습니다.


* **기존 물리적 이탈 로직 유지**
  * 앱을 종료한 유저와 달리, 앱을 켠 상태로 축제 구역(Bounding Box)을 완전히 벗어난 유저는 `VisitorLocationService`에서 기존대로 레디스 세션을 즉시 삭제(`deleteVisitorLocation`)하므로, 현실의 혼잡도가 정확하게 반영됩니다.



## #️⃣ 테스트 결과

### 로컬 테스트 검증 완료

* 유저 위치 저장 후 앱 종료(전송 중단) 시, 정확히 2분 동안 `getCellCounts` 결과에 포함되다가 이후 자동 소멸되는 것을 확인했습니다.


## #️⃣ 셀프 체크리스트

* [x] (Server) 로컬 환경에서 정상적으로 빌드되나요?
* [x] (Server) 예시 데이터를 통해 테스트를 마쳤나요?
* [ ] (Client) 화면이 깨지지 않고 렌더링되나요? (해당 없음)
* [ ] Swagger 문서가 최신화되었나요? (API 변경 사양 없음)
* [x] 코드 컨벤션을 준수했나요?

## #️⃣ 리뷰 요구사항




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 방문자 위치 데이터의 보존 시간을 연장하여 데이터 일관성 개선
  * Redis 조회 방식 최적화로 시스템 성능 향상 및 블로킹 현상 해소

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wagle-project/wagle-server/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->