### PR TITLE
[Chore] DB 커넥션 풀 사이즈 확장을 통한 동시 접속 성능 개선

### DIFF
--- a/src/main/java/com/waglewagle/server/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/waglewagle/server/global/apiPayload/code/GeneralErrorCode.java
@@ -13,7 +13,7 @@ public enum GeneralErrorCode implements BaseErrorCode{
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "요청한 리소스를 찾을 수 없습니다. 해당 경로는 존재하지 않습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 잠시 후 다시 시도해주세요."),
 
     // AUTH 관련 에러
     LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH4000", "로그인이 필요한 기능입니다."),

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,6 +10,9 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari: # DB 확장에 따른 커넥션 풀 확장
+      maximum-pool-size: 30
+      connection-timeout: 30000
   jpa:
     hibernate:
       ddl-auto: none

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari: # DB 확장에 따른 커넥션 풀 확장
       maximum-pool-size: 30
-      connection-timeout: 30000
+      connection-timeout: 3000
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #87

## #️⃣ 작업 내용

- `application.yml` 파일 내에 HikariCP 커넥션 풀 설정을 명시적으로 추가했습니다.
- 투명 로그인 과정에서 발생할 수 있는 초기 트래픽 스파이크(순간 동접 최대 2,000명 예상)를 소화하기 위해 `maximum-pool-size`를 30으로 조정했습니다.
- 커넥션 풀 고갈 시 서버 전체 장애로 전파되는 것을 방지하기 위해, 커넥션 획득 대기 시간(connection-timeout)을 3초로 짧게 설정하였습니다.
- 트래픽으로 인한 서버 장애 발생 시 사용자들의 새로고침을 유도할 수 있도록 에러 메시지를 변경하였습니다.

## #️⃣ 테스트 결과

- 로컬 환경(Docker DB 연동)에서 정상적으로 Spring Boot 애플리케이션이 실행되며, 초기화 로그에서 HikariCP pool size가 30으로 적용된 것을 확인했습니다.
- 투명 로그인 API(`POST /login` 등) 호출 시 정상적으로 UUID가 발급 및 DB에 저장되는 것을 확인했습니다.

## #️⃣ 셀프 체크리스트

- [x] (Server) 로컬 환경에서 정상적으로 빌드되나요?
- [x] (Server) 예시 데이터를 통해 테스트를 마쳤나요?
- [ ] (Client) 화면이 깨지지 않고 렌더링되나요?
- [x] Swagger 문서가 최신화되었나요? (API 변경 시)
- [x] 코드 컨벤션을 준수했나요?

## #️⃣ 리뷰 요구사항
- 작업 브랜치 명의 연관 이슈가 80번으로 작성되어 있는데 이는 오타입니다. 연관 이슈 87번이 맞습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 운영 환경의 데이터베이스 연결 풀 설정을 개선하여 최대 연결 수를 증대하고 연결 타임아웃 시간을 최적화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wagle-project/wagle-server/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->