### PR TITLE
feat: Redis HyperLogLog 기반 DAU 집계 및 Prometheus 메트릭 연동

### DIFF
--- a/src/main/java/com/waglewagle/server/domain/visitor/controller/VisitorController.java
+++ b/src/main/java/com/waglewagle/server/domain/visitor/controller/VisitorController.java
@@ -6,6 +6,7 @@ import com.waglewagle.server.domain.visitor.service.VisitorLocationService;
 import com.waglewagle.server.domain.visitor.service.VisitorService;
 import com.waglewagle.server.global.apiPayload.ApiResponse;
 import com.waglewagle.server.global.apiPayload.code.GeneralSuccessCode;
+import com.waglewagle.server.global.redis.annotation.TrackDau;
 import com.waglewagle.server.global.security.userdetails.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -22,6 +23,7 @@ public class VisitorController implements VisitorControllerDocs {
     private final VisitorLocationService visitorLocationService;
 
     @PostMapping("/visitors")
+    @TrackDau
     @Override
     public ApiResponse<VisitorDTO.VisitorResponse> registerVisitor(
             @RequestBody VisitorDTO.VisitorRequest request) {

--- a/src/main/java/com/waglewagle/server/global/config/WebConfig.java
+++ b/src/main/java/com/waglewagle/server/global/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.waglewagle.server.global.config;
+
+import com.waglewagle.server.global.redis.interceptor.DauInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final DauInterceptor dauInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        // 모든 경로를 대상으로 인터셉터를 추가하되, 실제 적용 여부는 인터셉터 내부에서 @TrackDau 존재 여부로 판단합니다.
+        registry.addInterceptor(dauInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**", "/health");
+    }
+}

--- a/src/main/java/com/waglewagle/server/global/redis/annotation/TrackDau.java
+++ b/src/main/java/com/waglewagle/server/global/redis/annotation/TrackDau.java
@@ -1,0 +1,24 @@
+package com.waglewagle.server.global.redis.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 특정 API 호출 시 일간 활성 사용자(DAU)를 집계하기 위한 어노테이션입니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackDau {
+
+    enum IdentifierType {
+        IP,
+        SESSION_ID
+    }
+
+    /**
+     * DAU 카운팅을 위한 클라이언트 식별 방법 (기본값: IP)
+     */
+    IdentifierType type() default IdentifierType.IP;
+}

--- a/src/main/java/com/waglewagle/server/global/redis/config/DauMetricsConfig.java
+++ b/src/main/java/com/waglewagle/server/global/redis/config/DauMetricsConfig.java
@@ -1,0 +1,27 @@
+package com.waglewagle.server.global.redis.config;
+
+import com.waglewagle.server.global.redis.service.DauService;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class DauMetricsConfig {
+
+    private final DauService dauService;
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * Micrometer Gauge 메트릭을 등록합니다.
+     * /actuator/prometheus가 호출될 때마다 DauService의 getDauCount()가 실시간 호출되어 Redis PFCOUNT 값을 반환합니다.
+     */
+    @PostConstruct
+    public void registerDauMetric() {
+        Gauge.builder("festival_dau_total", dauService, DauService::getDauCount)
+                .description("Daily Active Users count using Redis HyperLogLog")
+                .register(meterRegistry);
+    }
+}

--- a/src/main/java/com/waglewagle/server/global/redis/config/DauMetricsConfig.java
+++ b/src/main/java/com/waglewagle/server/global/redis/config/DauMetricsConfig.java
@@ -15,13 +15,19 @@ public class DauMetricsConfig {
     private final MeterRegistry meterRegistry;
 
     /**
-     * Micrometer Gauge 메트릭을 등록합니다.
-     * /actuator/prometheus가 호출될 때마다 DauService의 getDauCount()가 실시간 호출되어 Redis PFCOUNT 값을 반환합니다.
+     * Micrometer Gauge 메트릭들을 등록합니다.
+     * /actuator/prometheus가 호출될 때마다 DauService의 비즈니스 메서드가 실시간 호출되어 Redis PFCOUNT 값을 반환합니다.
      */
     @PostConstruct
-    public void registerDauMetric() {
+    public void registerDauMetrics() {
+        // 일간 활성 사용자 수 (DAU)
         Gauge.builder("festival_dau_total", dauService, DauService::getDauCount)
                 .description("Daily Active Users count using Redis HyperLogLog")
+                .register(meterRegistry);
+
+        // 시간대별 활성 사용자 수 (HAU)
+        Gauge.builder("festival_hau_total", dauService, DauService::getHourlyDauCount)
+                .description("Hourly Active Users count using Redis HyperLogLog")
                 .register(meterRegistry);
     }
 }

--- a/src/main/java/com/waglewagle/server/global/redis/interceptor/DauInterceptor.java
+++ b/src/main/java/com/waglewagle/server/global/redis/interceptor/DauInterceptor.java
@@ -4,6 +4,7 @@ import com.waglewagle.server.global.redis.annotation.TrackDau;
 import com.waglewagle.server.global.redis.service.DauService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -25,9 +26,12 @@ public class DauInterceptor implements HandlerInterceptor {
 
             if (trackDau != null) {
                 String identifier = extractIdentifier(request, trackDau.type());
-                log.info("Tracking DAU - URI: {}, Method: {}, Identifier: ({}) {}", 
-                        request.getRequestURI(), request.getMethod(), trackDau.type(), identifier);
-                dauService.addVisitor(identifier);
+                if (identifier != null && !identifier.isBlank()) {
+                    String masked = maskIdentifier(identifier, trackDau.type());
+                    log.info("Tracking DAU - URI: {}, Method: {}, Identifier: ({}) {}", 
+                            request.getRequestURI(), request.getMethod(), trackDau.type(), masked);
+                    dauService.addVisitor(identifier);
+                }
             }
         }
         return true;
@@ -35,7 +39,8 @@ public class DauInterceptor implements HandlerInterceptor {
 
     private String extractIdentifier(HttpServletRequest request, TrackDau.IdentifierType type) {
         if (type == TrackDau.IdentifierType.SESSION_ID) {
-            return request.getSession(true).getId();
+            HttpSession session = request.getSession(false);
+            return session != null ? session.getId() : null;
         }
 
         // IP 추출 로직 (프록시 환경 완벽 대처)
@@ -61,5 +66,30 @@ public class DauInterceptor implements HandlerInterceptor {
             ip = ip.split(",")[0].trim();
         }
         return ip;
+    }
+
+    /**
+     * 개인정보 보호(PII)를 위해 식별자를 마스킹 처리합니다.
+     */
+    private String maskIdentifier(String identifier, TrackDau.IdentifierType type) {
+        if (identifier == null || identifier.isBlank()) {
+            return "";
+        }
+        if (type == TrackDau.IdentifierType.IP) {
+            String[] parts = identifier.split("\\.");
+            if (parts.length == 4) {
+                return parts[0] + "." + parts[1] + ".***.***";
+            }
+            // IPv6 마스킹
+            if (identifier.contains(":")) {
+                return identifier.substring(0, Math.min(identifier.length(), 9)) + "::****";
+            }
+        } else {
+            // Session ID 마스킹 (앞 8자리만 유지)
+            if (identifier.length() > 8) {
+                return identifier.substring(0, 8) + "******";
+            }
+        }
+        return "****";
     }
 }

--- a/src/main/java/com/waglewagle/server/global/redis/interceptor/DauInterceptor.java
+++ b/src/main/java/com/waglewagle/server/global/redis/interceptor/DauInterceptor.java
@@ -1,0 +1,65 @@
+package com.waglewagle.server.global.redis.interceptor;
+
+import com.waglewagle.server.global.redis.annotation.TrackDau;
+import com.waglewagle.server.global.redis.service.DauService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DauInterceptor implements HandlerInterceptor {
+
+    private final DauService dauService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod handlerMethod = (HandlerMethod) handler;
+            TrackDau trackDau = handlerMethod.getMethodAnnotation(TrackDau.class);
+
+            if (trackDau != null) {
+                String identifier = extractIdentifier(request, trackDau.type());
+                log.info("Tracking DAU - URI: {}, Method: {}, Identifier: ({}) {}", 
+                        request.getRequestURI(), request.getMethod(), trackDau.type(), identifier);
+                dauService.addVisitor(identifier);
+            }
+        }
+        return true;
+    }
+
+    private String extractIdentifier(HttpServletRequest request, TrackDau.IdentifierType type) {
+        if (type == TrackDau.IdentifierType.SESSION_ID) {
+            return request.getSession(true).getId();
+        }
+
+        // IP 추출 로직 (프록시 환경 완벽 대처)
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+        }
+
+        // X-Forwarded-For 헤더에 쉼표(,)로 구분된 다중 IP가 유입될 경우 첫 번째 IP(실제 클라이언트 IP)만 추출
+        if (ip != null && ip.contains(",")) {
+            ip = ip.split(",")[0].trim();
+        }
+        return ip;
+    }
+}

--- a/src/main/java/com/waglewagle/server/global/redis/service/DauService.java
+++ b/src/main/java/com/waglewagle/server/global/redis/service/DauService.java
@@ -1,0 +1,61 @@
+package com.waglewagle.server.global.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DauService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String DAU_KEY_PREFIX = "dau:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    /**
+     * 오늘 날짜의 Redis 키에 클라이언트 식별자를 추가합니다. (PFADD)
+     *
+     * @param identifier 클라이언트 식별자 (IP or Session ID 등)
+     */
+    public void addVisitor(String identifier) {
+        if (identifier == null || identifier.isBlank()) {
+            return;
+        }
+        String todayKey = getTodayKey();
+        try {
+            redisTemplate.opsForHyperLogLog().add(todayKey, identifier);
+            log.debug("Successfully added identifier: {} to HyperLogLog key: {}", identifier, todayKey);
+        } catch (Exception e) {
+            log.error("Failed to add visitor identifier to Redis HyperLogLog", e);
+        }
+    }
+
+    /**
+     * 오늘 날짜의 Redis 키에 저장된 고유 사용자 수(DAU)를 조회합니다. (PFCOUNT)
+     *
+     * @return 일간 활성 사용자 수
+     */
+    public long getDauCount() {
+        String todayKey = getTodayKey();
+        try {
+            Long count = redisTemplate.opsForHyperLogLog().size(todayKey);
+            return count != null ? count : 0L;
+        } catch (Exception e) {
+            log.error("Failed to count DAU from Redis HyperLogLog, returning 0", e);
+            return 0L;
+        }
+    }
+
+    /**
+     * 오늘 날짜의 Redis Key를 생성합니다. (예: dau:2026-05-25)
+     */
+    private String getTodayKey() {
+        return DAU_KEY_PREFIX + LocalDate.now().format(DATE_FORMATTER);
+    }
+}

--- a/src/main/java/com/waglewagle/server/global/redis/service/DauService.java
+++ b/src/main/java/com/waglewagle/server/global/redis/service/DauService.java
@@ -1,25 +1,33 @@
 package com.waglewagle.server.global.redis.service;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class DauService {
 
     private final StringRedisTemplate redisTemplate;
+    private final ZoneId zoneId;
 
     private static final String DAU_KEY_PREFIX = "dau:";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final DateTimeFormatter HOURLY_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd:HH");
+
+    public DauService(StringRedisTemplate redisTemplate,
+                      @Value("${app.timezone:Asia/Seoul}") String timezone) {
+        this.redisTemplate = redisTemplate;
+        this.zoneId = ZoneId.of(timezone);
+        log.info("Initialized DauService with timezone: {}", this.zoneId);
+    }
 
     /**
      * 오늘 날짜의 Redis 키 및 현재 시간대별 키에 클라이언트 식별자를 추가합니다. (PFADD)
@@ -83,13 +91,13 @@ public class DauService {
      * 오늘 날짜의 Redis Key를 생성합니다. (예: dau:2026-05-25)
      */
     private String getTodayKey() {
-        return DAU_KEY_PREFIX + LocalDate.now().format(DATE_FORMATTER);
+        return DAU_KEY_PREFIX + LocalDate.now(zoneId).format(DATE_FORMATTER);
     }
 
     /**
      * 현재 시간대별 Redis Key를 생성합니다. (예: dau:2026-05-25:21)
      */
     private String getHourlyKey() {
-        return DAU_KEY_PREFIX + LocalDateTime.now().format(HOURLY_FORMATTER);
+        return DAU_KEY_PREFIX + LocalDateTime.now(zoneId).format(HOURLY_FORMATTER);
     }
 }

--- a/src/main/java/com/waglewagle/server/global/redis/service/DauService.java
+++ b/src/main/java/com/waglewagle/server/global/redis/service/DauService.java
@@ -5,7 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Slf4j
@@ -17,9 +19,10 @@ public class DauService {
 
     private static final String DAU_KEY_PREFIX = "dau:";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter HOURLY_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd:HH");
 
     /**
-     * 오늘 날짜의 Redis 키에 클라이언트 식별자를 추가합니다. (PFADD)
+     * 오늘 날짜의 Redis 키 및 현재 시간대별 키에 클라이언트 식별자를 추가합니다. (PFADD)
      *
      * @param identifier 클라이언트 식별자 (IP or Session ID 등)
      */
@@ -28,9 +31,17 @@ public class DauService {
             return;
         }
         String todayKey = getTodayKey();
+        String hourlyKey = getHourlyKey();
         try {
+            // 1. 일간 활성 사용자 수 집계 (DAU)
             redisTemplate.opsForHyperLogLog().add(todayKey, identifier);
-            log.debug("Successfully added identifier: {} to HyperLogLog key: {}", identifier, todayKey);
+
+            // 2. 시간대별 활성 사용자 수 집계 (HAU)
+            redisTemplate.opsForHyperLogLog().add(hourlyKey, identifier);
+            // 메모리 관리를 위해 시간대별 키에는 48시간의 TTL 부여
+            redisTemplate.expire(hourlyKey, Duration.ofHours(48));
+
+            log.debug("Successfully added identifier: {} to HyperLogLog keys: {}, {}", identifier, todayKey, hourlyKey);
         } catch (Exception e) {
             log.error("Failed to add visitor identifier to Redis HyperLogLog", e);
         }
@@ -53,9 +64,32 @@ public class DauService {
     }
 
     /**
+     * 현재 시간대별 Redis 키에 저장된 고유 사용자 수(HAU)를 조회합니다. (PFCOUNT)
+     *
+     * @return 시간대별 활성 사용자 수
+     */
+    public long getHourlyDauCount() {
+        String hourlyKey = getHourlyKey();
+        try {
+            Long count = redisTemplate.opsForHyperLogLog().size(hourlyKey);
+            return count != null ? count : 0L;
+        } catch (Exception e) {
+            log.error("Failed to count Hourly Active Users from Redis HyperLogLog, returning 0", e);
+            return 0L;
+        }
+    }
+
+    /**
      * 오늘 날짜의 Redis Key를 생성합니다. (예: dau:2026-05-25)
      */
     private String getTodayKey() {
         return DAU_KEY_PREFIX + LocalDate.now().format(DATE_FORMATTER);
+    }
+
+    /**
+     * 현재 시간대별 Redis Key를 생성합니다. (예: dau:2026-05-25:21)
+     */
+    private String getHourlyKey() {
+        return DAU_KEY_PREFIX + LocalDateTime.now().format(HOURLY_FORMATTER);
     }
 }

--- a/src/test/java/com/waglewagle/server/global/redis/service/DauServiceTest.java
+++ b/src/test/java/com/waglewagle/server/global/redis/service/DauServiceTest.java
@@ -1,0 +1,65 @@
+package com.waglewagle.server.global.redis.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HyperLogLogOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DauServiceTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private HyperLogLogOperations<String, String> hyperLogLogOperations;
+
+    @InjectMocks
+    private DauService dauService;
+
+    private String todayKey;
+
+    @BeforeEach
+    void setUp() {
+        todayKey = "dau:" + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+
+    @Test
+    void addVisitor_success() {
+        // given
+        String identifier = "192.168.0.1";
+        when(redisTemplate.opsForHyperLogLog()).thenReturn(hyperLogLogOperations);
+        when(hyperLogLogOperations.add(eq(todayKey), eq(identifier))).thenReturn(1L);
+
+        // when
+        dauService.addVisitor(identifier);
+
+        // then
+        verify(hyperLogLogOperations, times(1)).add(eq(todayKey), eq(identifier));
+    }
+
+    @Test
+    void getDauCount_success() {
+        // given
+        when(redisTemplate.opsForHyperLogLog()).thenReturn(hyperLogLogOperations);
+        when(hyperLogLogOperations.size(eq(todayKey))).thenReturn(5L);
+
+        // when
+        long count = dauService.getDauCount();
+
+        // then
+        assertEquals(5L, count);
+        verify(hyperLogLogOperations, times(1)).size(eq(todayKey));
+    }
+}

--- a/src/test/java/com/waglewagle/server/global/redis/service/DauServiceTest.java
+++ b/src/test/java/com/waglewagle/server/global/redis/service/DauServiceTest.java
@@ -3,7 +3,6 @@ package com.waglewagle.server.global.redis.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.HyperLogLogOperations;
@@ -12,6 +11,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,16 +28,17 @@ class DauServiceTest {
     @Mock
     private HyperLogLogOperations<String, String> hyperLogLogOperations;
 
-    @InjectMocks
     private DauService dauService;
 
     private String todayKey;
     private String hourlyKey;
+    private static final ZoneId TEST_ZONE = ZoneId.of("Asia/Seoul");
 
     @BeforeEach
     void setUp() {
-        todayKey = "dau:" + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-        hourlyKey = "dau:" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd:HH"));
+        dauService = new DauService(redisTemplate, "Asia/Seoul");
+        todayKey = "dau:" + LocalDate.now(TEST_ZONE).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        hourlyKey = "dau:" + LocalDateTime.now(TEST_ZONE).format(DateTimeFormatter.ofPattern("yyyy-MM-dd:HH"));
     }
 
     @Test

--- a/src/test/java/com/waglewagle/server/global/redis/service/DauServiceTest.java
+++ b/src/test/java/com/waglewagle/server/global/redis/service/DauServiceTest.java
@@ -9,10 +9,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.HyperLogLogOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -29,10 +32,12 @@ class DauServiceTest {
     private DauService dauService;
 
     private String todayKey;
+    private String hourlyKey;
 
     @BeforeEach
     void setUp() {
         todayKey = "dau:" + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        hourlyKey = "dau:" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd:HH"));
     }
 
     @Test
@@ -41,12 +46,16 @@ class DauServiceTest {
         String identifier = "192.168.0.1";
         when(redisTemplate.opsForHyperLogLog()).thenReturn(hyperLogLogOperations);
         when(hyperLogLogOperations.add(eq(todayKey), eq(identifier))).thenReturn(1L);
+        when(hyperLogLogOperations.add(eq(hourlyKey), eq(identifier))).thenReturn(1L);
+        when(redisTemplate.expire(eq(hourlyKey), any(Duration.class))).thenReturn(true);
 
         // when
         dauService.addVisitor(identifier);
 
         // then
         verify(hyperLogLogOperations, times(1)).add(eq(todayKey), eq(identifier));
+        verify(hyperLogLogOperations, times(1)).add(eq(hourlyKey), eq(identifier));
+        verify(redisTemplate, times(1)).expire(eq(hourlyKey), eq(Duration.ofHours(48)));
     }
 
     @Test
@@ -61,5 +70,19 @@ class DauServiceTest {
         // then
         assertEquals(5L, count);
         verify(hyperLogLogOperations, times(1)).size(eq(todayKey));
+    }
+
+    @Test
+    void getHourlyDauCount_success() {
+        // given
+        when(redisTemplate.opsForHyperLogLog()).thenReturn(hyperLogLogOperations);
+        when(hyperLogLogOperations.size(eq(hourlyKey))).thenReturn(3L);
+
+        // when
+        long count = dauService.getHourlyDauCount();
+
+        // then
+        assertEquals(3L, count);
+        verify(hyperLogLogOperations, times(1)).size(eq(hourlyKey));
     }
 }


### PR DESCRIPTION
## 개요 (Overview)
현재 Spring Boot 프로젝트에서 Redis의 **HyperLogLog(PFADD/PFCOUNT)** 자료구조를 활용해 일간 활성 사용자 수(DAU)를 효율적으로 측정하고, 이를 **Micrometer Gauge**를 활용하여 Prometheus 메트릭(`festival_dau_total`)으로 안전하게 노출하는 모니터링 환경을 완성했습니다.

## 주요 변경 사항 (Proposed Changes)
1. **커스텀 `@TrackDau` 어노테이션 추가**
   - API 레벨에서 간편하고 유연하게 DAU 카운팅 타겟을 지정할 수 있습니다. 
   - IP 기반(`IdentifierType.IP`) 및 세션 ID 기반(`IdentifierType.SESSION_ID`) 측정 방식을 명시할 수 있습니다.
2. **`DauService` 비즈니스 서비스 구현**
   - 오늘 날짜 기준의 Redis Key(`dau:yyyy-MM-dd`)에 대해 `opsForHyperLogLog().add()` 및 `size()` 호출을 캡슐화합니다.
3. **`DauInterceptor` 및 `WebConfig` 웹 연동**
   - 역방향 프록시 헤더(`X-Forwarded-For` 등)를 올바르게 처리해 실제 클라이언트 IP를 실시간으로 추출하고 Redis에 기록합니다.
   - 불필요한 시스템 경로(/actuator 등)를 필터링 대상에서 제외하여 최적화했습니다.
4. **`DauMetricsConfig` 모니터링 메트릭 노출**
   - Micrometer의 `Gauge`를 빈으로 등록하여 `/actuator/prometheus` 스크랩 주기마다 Redis의 최신 PFCOUNT 값을 동적으로 노출합니다.
5. **API 적용 및 테스트**
   - `VisitorController`의 `/visitors` (방문자 등록) API에 `@TrackDau`를 적용해 연동 시범을 보였습니다.
   - `DauServiceTest` 단위 테스트를 작성해 의존성 없이 로직이 정상 작동함을 통과 확인했습니다.

## 검증 결과 (Verification Results)
- `./gradlew compileJava`: 컴파일 성공 완료
- `./gradlew test --tests "com.waglewagle.server.global.redis.service.DauServiceTest"`: 단위 테스트 빌드 및 통과 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 일일 활성 사용자(DAU) 및 시간대별 활성 사용자(HAU) 자동 집계 기능이 추가되었습니다.
  * 특정 요청에 대해 트래킹을 적용할 수 있는 어노테이션 기반 선택적 추적 지원이 포함됩니다.
  * Micrometer를 통한 DAU/HAU 실시간 메트릭이 등록되어 모니터링에서 확인 가능합니다.

* **Tests**
  * DAU/HAU 집계 로직에 대한 단위 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wagle-project/wagle-server/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->