### PR TITLE
feat: Redis HyperLogLog-based DAU/HAU and Prometheus/Grafana Unified Deployment

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -49,13 +49,13 @@ jobs:
           password: ${{ secrets.NCP_PASSWORD }}
           script: mkdir -p /root/deploy
 
-      - name: Copy docker-compose.yml to NCP
+      - name: Copy deployment and config files to NCP
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ vars.NCP_HOST }}
           username: ${{ secrets.NCP_USERNAME || 'root' }}
           password: ${{ secrets.NCP_PASSWORD }}
-          source: "infra/docker-compose.yml"
+          source: "infra/docker-compose.yml,infra/docker-compose-local.yml,infra/prometheus/prometheus.yml"
           target: /root/deploy
 
       - name: Deploy to NCP via SSH

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -65,6 +65,35 @@ services:
     networks:
       - wagle-network
 
+  # 5. Prometheus (메트릭 수집 엔진)
+  wagle-prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: wagle-prometheus
+    restart: always
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - wagle-network
+
+  # 6. Grafana (시각화 대시보드)
+  wagle-grafana:
+    image: grafana/grafana:11.5.2
+    container_name: wagle-grafana
+    restart: always
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
+    volumes:
+      - ./grafana_data:/var/lib/grafana
+    depends_on:
+      - wagle-prometheus
+    networks:
+      - wagle-network
+
 networks:
   wagle-network:
     driver: bridge

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -7,4 +7,4 @@ scrape_configs:
     scrape_interval: 5s  # 5초마다 메트릭 수집
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8080']
+      - targets: ['wagle-app:8080', 'host.docker.internal:8080']

--- a/src/test/java/com/waglewagle/server/domain/festivalMap/CongestionServiceTest.java
+++ b/src/test/java/com/waglewagle/server/domain/festivalMap/CongestionServiceTest.java
@@ -57,17 +57,17 @@ class CongestionServiceTest {
                 .willReturn(Optional.of(festivalMap));
         given(locationRedisRepository.getCellCounts(7L))
                 .willReturn(Map.of(
-                        "cell_A", 3,   // level 0 (0~5명)
-                        "cell_B", 10,  // level 1 (6~15명)
-                        "cell_C", 20,  // level 2 (16~30명)
-                        "cell_D", 35   // level 3 (31명 이상)
+                        "cell_A", 1,   // level 1 (< 2명)
+                        "cell_B", 2,   // level 2 (2명)
+                        "cell_C", 3,   // level 3 (>= 3명)
+                        "cell_D", 5    // level 3 (>= 3명)
                 ));
 
         // when
         CongestionDTO.CongestionResponse response = congestionService.getCongestion(7L);
 
         // then
-        assertThat(response.totalCount()).isEqualTo(68);
+        assertThat(response.totalCount()).isEqualTo(11);
         assertThat(response.zones()).hasSize(4);
 
         Map<String, Integer> levelMap = response.zones().stream()
@@ -76,9 +76,9 @@ class CongestionServiceTest {
                         CongestionDTO.ZoneInfo::level
                 ));
 
-        assertThat(levelMap.get("cell_A")).isEqualTo(0);
-        assertThat(levelMap.get("cell_B")).isEqualTo(1);
-        assertThat(levelMap.get("cell_C")).isEqualTo(2);
+        assertThat(levelMap.get("cell_A")).isEqualTo(1);
+        assertThat(levelMap.get("cell_B")).isEqualTo(2);
+        assertThat(levelMap.get("cell_C")).isEqualTo(3);
         assertThat(levelMap.get("cell_D")).isEqualTo(3);
     }
 
@@ -112,19 +112,18 @@ class CongestionServiceTest {
     }
 
     @Test
-    @DisplayName("혼잡도 레벨 경계값 확인 - 5명/6명/15명/16명/30명/31명")
+    @DisplayName("혼잡도 레벨 경계값 확인 - 0명/1명/2명/3명")
     void getCongestion_levelBoundary() {
         // given
         given(festivalMapRepository.findById(7L))
                 .willReturn(Optional.of(festivalMap));
         given(locationRedisRepository.getCellCounts(7L))
                 .willReturn(Map.of(
-                        "cell_1", 5,   // level 1 최대
-                        "cell_2", 6,   // level 2 최소
-                        "cell_3", 15,  // level 2 최대
-                        "cell_4", 16,  // level 3 최소
-                        "cell_5", 30,  // level 3 최대
-                        "cell_6", 31   // level 4 최소
+                        "cell_1", 0,   // level 1
+                        "cell_2", 1,   // level 1
+                        "cell_3", 2,   // level 2
+                        "cell_4", 3,   // level 3
+                        "cell_5", 10   // level 3
                 ));
 
         // when
@@ -137,11 +136,10 @@ class CongestionServiceTest {
                         CongestionDTO.ZoneInfo::level
                 ));
 
-        assertThat(levelMap.get("cell_1")).isEqualTo(0);
+        assertThat(levelMap.get("cell_1")).isEqualTo(1);
         assertThat(levelMap.get("cell_2")).isEqualTo(1);
-        assertThat(levelMap.get("cell_3")).isEqualTo(1);
-        assertThat(levelMap.get("cell_4")).isEqualTo(2);
-        assertThat(levelMap.get("cell_5")).isEqualTo(2);
-        assertThat(levelMap.get("cell_6")).isEqualTo(3);
+        assertThat(levelMap.get("cell_3")).isEqualTo(2);
+        assertThat(levelMap.get("cell_4")).isEqualTo(3);
+        assertThat(levelMap.get("cell_5")).isEqualTo(3);
     }
 }


### PR DESCRIPTION
## 개요 (Overview)
이전 PR(#90)이 종료된 이후, 시간대별 고유 활성 사용자 수(HAU) 측정 및 마스킹/보안성 강화 기능, 그리고 배포 편의성을 위해 Prometheus와 Grafana 서비스를 메인 `docker-compose.yml` 파일로 단일 통합한 핵심 코드 변경 사항을 새롭게 배포하기 위한 Pull Request입니다.

## 주요 변경 사항 (Proposed Changes)
1. **Prometheus & Grafana 단일 통합 배포화**:
   - `infra/docker-compose.yml` 메인 배포 파일에 `wagle-prometheus` 및 `wagle-grafana` 서비스를 직접 병합하여 단일 컴포즈 명령어로 실행 가능하게 최적화했습니다.
   - 동일한 브릿지 네트워크(`wagle-network`)로 격리 배치하여, 외부 호스트 경유 없이 내부 도커 DNS(`wagle-app:8080`)를 통해 실시간 메트릭을 안전하게 수집하도록 `prometheus.yml` 설정을 고도화했습니다. (로컬 디버깅용 `host.docker.internal` 폴백도 지원)
2. **시간대별 활성 사용자 수 (HAU) 측정 및 노출**:
   - 일간 키(`dau:yyyy-MM-dd`)와 함께 시간대별 키(`dau:yyyy-MM-dd:HH`)를 생성하여 유니크 HAU 수치를 동시에 수집합니다.
   - 시간대별 키는 메모리 절약을 위해 **48시간의 TTL**을, 일간 키는 실증 기간을 감안해 **7일의 TTL**을 설정했습니다.
   - `festival_hau_total` Gauge 메트릭을 추가로 등록하여 Grafana 대시보드에서 시간대별 접속 분포 그래프를 실시간 모니터링할 수 있습니다.
3. **개인정보 보호(PII) 로깅 마스킹 및 세션 오버헤드 최적화**:
   - IP와 세션 ID 정보가 평문 로그로 유출되지 않도록 마스킹 유틸리티를 적용했습니다.
   - `request.getSession(false)`를 사용하여 불필요한 HTTP Session 생성을 억제하고 리소스 낭비를 차단했습니다.
4. **배포 자동화 파일 전송 동기화**:
   - 깃허브 액션 배포 스크립트(`_deploy.yml`)에서 프로메테우스 및 그라파나 실행에 필요한 설정 파일들을 배포 서버로 함께 자동 전송하도록 보강했습니다.

## 검증 결과 (Verification Results)
- `./gradlew compileJava` 및 Mockito 단위 테스트(`DauServiceTest`)가 모두 정상 빌드 및 성공 완료되었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 모니터링 및 대시보드 서비스 인프라 추가
  * 모니터링 대상 범위 확장

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wagle-project/wagle-server/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->